### PR TITLE
Gfanlib

### DIFF
--- a/Singular/bbpolytope.cc
+++ b/Singular/bbpolytope.cc
@@ -89,7 +89,9 @@ char* bbpolytope_String(blackbox *b, void *d)
 { if (d==NULL) return omStrDup("invalid object");
    else
    {
-     std::string s=bbpolytopeToString(*((gfan::ZCone*)d));
+     gfan::ZCone* zc = (gfan::ZCone*)d;
+     zc->canonicalize();
+     std::string s=bbpolytopeToString(*zc);
      return omStrDup(s.c_str());
    }
 }
@@ -138,13 +140,6 @@ static BOOLEAN ppCONERAYS3(leftv res, leftv u, leftv v)
      if the k=1, then the extreme rays are known:
      each half-line spans a (different) extreme ray */
   intvec* rays = (intvec *)u->CopyD(INTVEC_CMD);
-  intvec* linSpace = (intvec *)v->CopyD(INTVEC_CMD);
-  if (rays->cols() != linSpace->cols())
-  {
-    Werror("expected same number of columns but got %d vs. %d",
-           rays->cols(), linSpace->cols());
-    return TRUE;
-  }
   int k = (int)(long)v->Data();
   if ((k < 0) || (k > 1))
   {
@@ -152,10 +147,9 @@ static BOOLEAN ppCONERAYS3(leftv res, leftv u, leftv v)
     return TRUE;
   }
   k=k*2;
-  gfan::ZMatrix zm1 = intmat2ZMatrix(rays);
-  gfan::ZMatrix zm2;
+  gfan::ZMatrix zm = intmat2ZMatrix(rays);
   gfan::ZCone* zc = new gfan::ZCone();
-  *zc = gfan::ZCone::givenByRays(zm1, zm2);
+  *zc = gfan::ZCone::givenByRays(zm,gfan::ZMatrix(0, zm.getWidth()));
   zc->canonicalize();
   //k should be passed on to zc; not available yet
   res->rtyp = polytopeID;
@@ -206,13 +200,6 @@ static BOOLEAN pqCONERAYS3(leftv res, leftv u, leftv v)
      if the k=1, then the extreme rays are known:
      each half-line spans a (different) extreme ray */
   intvec* rays = (intvec *)u->CopyD(INTVEC_CMD);
-  intvec* linSpace = (intvec *)v->CopyD(INTVEC_CMD);
-  if (rays->cols() != linSpace->cols())
-  {
-    Werror("expected same number of columns but got %d vs. %d",
-           rays->cols(), linSpace->cols());
-    return TRUE;
-  }
   int k = (int)(long)v->Data();
   if ((k < 0) || (k > 1))
   {
@@ -220,10 +207,9 @@ static BOOLEAN pqCONERAYS3(leftv res, leftv u, leftv v)
     return TRUE;
   }
   k=k*2;
-  gfan::ZMatrix zm1 = intmat2ZMatrix(rays);
-  gfan::ZMatrix zm2;
+  gfan::ZMatrix zm = intmat2ZMatrix(rays);
   gfan::ZCone* zc = new gfan::ZCone();
-  *zc = gfan::ZCone::givenByRays(zm1, zm2);
+  *zc = gfan::ZCone::givenByRays(zm,gfan::ZMatrix(0, zm.getWidth()));
   //k should be passed on to zc; not available yet
   res->rtyp = polytopeID;
   res->data = (char *)zc;

--- a/doc/cones.doc
+++ b/doc/cones.doc
@@ -1734,7 +1734,7 @@ intmat V[4][3]=
 1,0,1,
 1,1,1;
 polytope p=polytopeViaVertices(V);
-c;
+p;
 // the input points are exactly the vertices:
 intmat V[4][3]= 
 1,0,0,
@@ -1742,7 +1742,7 @@ intmat V[4][3]=
 1,0,1,
 1,1,1;
 polytope p=polytopeViaVertices(V,1);
-c;
+p;
 @c example
 @end smallexample
 @end table
@@ -1774,6 +1774,7 @@ intmat IE[2][3]=
 intmat E[1][3]=
 0,0,1;
 polytope p=polytopeViaNormals(IE,E);
+p;
 @c example
 @end smallexample
 @end table
@@ -1819,7 +1820,7 @@ intmat M[4][3]=
 1,2,2,
 1,1,1;
 polytope p=polytopeViaPoints(M);
-print(getVertices(p));
+p;
 @c end example getCone cones.doc:818
 @end smallexample
 @end table


### PR DESCRIPTION
fixed polytopeViaVertices, forgot to remove a bit of code that was left from the cones.
changed printout of polytopes, so that they are canonicalized while being printed out instead of a copy of them.
