### PR TITLE
Fix Bug in newstruct's custom operations

### DIFF
--- a/Singular/newstruct.cc
+++ b/Singular/newstruct.cc
@@ -278,7 +278,7 @@ BOOLEAN newstruct_Op2(int op, leftv res, leftv a1, leftv a2)
     al=(lists)a2->Data();
   }
   newstruct_proc p=nt->procs;
-  while((p!=NULL) &&(p->t=op)&&(p->args!=2)) p=p->next;
+  while((p!=NULL) && ( (p->t!=op) || (p->args!=2) )) p=p->next;
   if (p!=NULL)
   {
     leftv sl;
@@ -321,7 +321,9 @@ BOOLEAN newstruct_OpM(int op, leftv res, leftv args)
       break;
   }
   newstruct_proc p=nt->procs;
-  while((p!=NULL) &&(p->t=op)&&(p->args!=4)) p=p->next;
+  
+  while((p!=NULL) &&( (p->t!=op) || (p->args!=4) )) p=p->next;
+
   if (p!=NULL)
   {
     leftv sl;


### PR DESCRIPTION
The following code

``` C
proc divisor_print(divisor D)
{
"Divisor = ("+string(D.den)+") - ("+string(D.num)+")";
}
proc divisor_status(divisor D)
{
  return ("status");
}
proc divisor_test(divisor D)
{
  return ("test");
}
proc divisor_gcd(divisor D, divisor D2)
{
  return ("gcd");
}
proc divisor_extgcd(divisor D, divisor D2)
{
  return ("extgcd");
}
proc divisor_diff(divisor D, divisor D2)
{
  return ("diff");
}

newstruct("divisor","ideal den,ideal num");
newstruct("formaldivisor","list summands");
newstruct("pdivisor","list summands, cone tail");

system("install","divisor","status",divisor_status, 4);
system("install","divisor","test",divisor_test,4);
system("install","divisor","gcd",divisor_gcd,2);
system("install","divisor","extgcd",divisor_extgcd,2);


system("install","divisor","print",divisor_print,1);

ring r=0,(x,y),dp;

divisor C;
C.num = ideal(x);
C.den = ideal(y);

C;
test(C);
status(C);
gcd(C,C);
extgcd(C,C);
```

results in

``` C
Divisor = (y) - (x)

test
test
extgcd
extgcd
```

The reason is that there in an assignment instead of a comparison in newstruct.cc. This request fixes it.
