### PR TITLE
Better Interaction between custom blackbox types

### DIFF
--- a/Singular/newstruct.cc
+++ b/Singular/newstruct.cc
@@ -611,19 +611,13 @@ error_in_newstruct_def:
    currRingHdl=save_ring;
    return NULL;
 }
-
-newstruct_desc newstructDesc()
+newstruct_desc newstructFromString(const char *s)
 {
   newstruct_desc res=(newstruct_desc)omAlloc0(sizeof(*res));
   res->size=0;
-  return res;
-}
 
-newstruct_desc newstructFromString(const char *s)
-{
-  return scanNewstructFromString(s, newstructDesc());
+  return scanNewstructFromString(s,res);
 }
-
 newstruct_desc newstructChildFromString(const char *parent, const char *s)
 {
   // find parent:
@@ -668,6 +662,13 @@ BOOLEAN newstruct_set_proc(const char *bbname,const char *func, int args,procinf
   blackboxIsCmd(bbname,id);
   blackbox *bb=getBlackboxStuff(id);
   newstruct_desc desc=(newstruct_desc)bb->data;
+  if (desc == NULL)
+  {
+    desc=(newstruct_desc)omAlloc0(sizeof(*desc));
+    desc->size=0;
+    bb->data = (void*)desc;
+  }
+
   newstruct_proc p=(newstruct_proc)omAlloc(sizeof(*p));
   p->next=desc->procs; desc->procs=p;
   if(!IsCmd(func,p->t))

--- a/Singular/newstruct.h
+++ b/Singular/newstruct.h
@@ -4,9 +4,9 @@
 typedef struct newstruct_desc_s *newstruct_desc;
 
 void newstruct_setup(const char * name, newstruct_desc d);
-newstruct_desc newstructDesc();
 newstruct_desc newstructFromString(const char *s);
 newstruct_desc newstructChildFromString(const char *p, const char *s);
 BOOLEAN newstruct_set_proc(const char *name,const char *func,int args, procinfov p);
 void newstructShow(newstruct_desc d);
+
 #endif

--- a/Singular/pyobject.cc
+++ b/Singular/pyobject.cc
@@ -20,7 +20,6 @@
 
 #include <Singular/ipid.h>
 #include <Singular/blackbox.h>
-#include <Singular/newstruct.h>
 
 #include <omalloc/omalloc.h>
 #include <kernel/febase.h>
@@ -656,7 +655,6 @@ void pyobject_init()
   b->blackbox_Op2     = pyobject_Op2;
   b->blackbox_Op3     = pyobject_Op3;
   b->blackbox_OpM     = pyobject_OpM;
-  b->data = newstructDesc();
 
   PythonInterpreter::init(setBlackboxStuff(b,"pyobject"));
 


### PR DESCRIPTION
pyobject can be converted to a given newstruct and vice versa, if customly defined.
Patch f84fa591... also fixes a segfault on errorous user commands.

``` C
newstruct("wrapping","pyobject obj");

proc to_pyobject(wrapping obj)
{
  return (obj.obj);
}

system("install", "wrapping", "pyobject", to_pyobject, 1);

wrapping wrapped;

pyobject(wrapped); // -> None

pyobject extracted = wrapped;
extracted; // -> None

proc auto_dewrap(pyobject obj)
{
  return (obj);
}

auto_dewrap(wrapped); // -> None

proc to_wrapping(pyobject obj)
{
  wrapping result;
  result.obj = obj;
  return (result);
}

system("install", "pyobject", "wrapping", to_wrapping, 1);

wrapping next = extracted;
next;                              // -> obj=None
wrapping(extracted);   // -> obj=None
```
