### PR TITLE
Fix: newstruct convertible to poly

### DIFF
--- a/Singular/newstruct.cc
+++ b/Singular/newstruct.cc
@@ -671,6 +671,10 @@ BOOLEAN newstruct_set_proc(const char *bbname,const char *func, int args,procinf
 
   newstruct_proc p=(newstruct_proc)omAlloc(sizeof(*p));
   p->next=desc->procs; desc->procs=p;
+
+  idhdl save_ring=currRingHdl;
+  currRingHdl=(idhdl)1; // fake ring detection
+
   if(!IsCmd(func,p->t))
   {
     int t=0;
@@ -682,10 +686,12 @@ BOOLEAN newstruct_set_proc(const char *bbname,const char *func, int args,procinf
     else
     {
       Werror(">>%s<< is not a kernel command",func);
+      currRingHdl = save_ring;
       return TRUE;
     }
   }
   p->args=args;
   p->p=pr; pr->ref++;
+  currRingHdl = save_ring;
   return FALSE;
 }


### PR DESCRIPTION
``` C
newstruct("wrapping","int i");

proc to_poly(wrapping obj)
{
return (var(obj.i+1));
}

system("install", "wrapping", "poly", to_poly, 1);
wrapping wrapped;
ring r = 0,x,dp;
poly(wrapped); // -> x

```
