### PR TITLE
Fix: None pyobject

### DIFF
--- a/Singular/pyobject.cc
+++ b/Singular/pyobject.cc
@@ -274,7 +274,7 @@ protected:
 private:
   BOOLEAN none_to(leftv result) const
   {
-    Py_XINCREF(m_ptr);
+    Py_XDECREF(m_ptr);
     result->data = NULL;
     result->rtyp = NONE;
     return FALSE;


### PR DESCRIPTION
The reference count of the Python's singleton object `None` was not handles correctly,
