### PR TITLE
Gfanlib

### DIFF
--- a/callgfanlib/bbcone.cc
+++ b/callgfanlib/bbcone.cc
@@ -1506,7 +1506,7 @@ void bbcone_setup()
   iiAddCproc("","coneViaInequalities",FALSE,coneViaNormals);
   iiAddCproc("","coneViaPoints",FALSE,coneViaRays);
   iiAddCproc("","canonicalizeCone",FALSE,canonicalizeCone);
-  iiAddCproc("","makePolytope",FALSE,coneToPolytope);
+  // iiAddCproc("","makePolytope",FALSE,coneToPolytope);
 
   iiAddCproc("","inequalities",FALSE,inequalities);
   iiAddCproc("","facets",FALSE,facets);
@@ -1527,7 +1527,7 @@ void bbcone_setup()
   iiAddCproc("","setLinearForms",FALSE,setLinearForms);
   iiAddCproc("","linearForms",FALSE,linearForms);
 
-  iiAddCproc("","dual",FALSE,dualCone);
+  iiAddCproc("","dualCone",FALSE,dualCone);
   iiAddCproc("","negatedCone",FALSE,negatedCone);
   iiAddCproc("","coneLink",FALSE,coneLink);
   iiAddCproc("","convexIntersection",FALSE,intersectCones);

--- a/callpolymake/polymake_wrapper.cc
+++ b/callpolymake/polymake_wrapper.cc
@@ -1,25 +1,6 @@
 #include <polymake_conversion.h>
 #include <polymake_documentation.h>
 
-// #include <polymake/Main.h>
-// #include <polymake/Matrix.h>
-// #include <polymake/Rational.h>
-// #include <polymake/Integer.h>
-// #include <polymake/common/lattice_tools.h>
-// #include <polymake/perl/macros.h>
-// #include <polymake/Set.h>
-// #include <polymake/IncidenceMatrix.h>
-
-// #include <gfanlib/gfanlib.h>
-// #include <gfanlib/gfanlib_q.h>
-
-// #include <gmpxx.h>
-
-// #include <kernel/mod2.h>
-// #include <kernel/structs.h>
-// #include <kernel/febase.h>
-// #include <kernel/intvec.h>
-
 #include <callgfanlib/bbcone.h>
 #include <callgfanlib/bbfan.h>
 #include <callgfanlib/bbpolytope.h>
@@ -27,7 +8,6 @@
 #include <Singular/blackbox.h>
 #include <Singular/ipshell.h>
 #include <Singular/subexpr.h>
-// #include <Singular/tok.h>
 
 using namespace polymake;
 
@@ -1636,185 +1616,6 @@ BOOLEAN normalFan(leftv res, leftv args)
   return TRUE; 
 }
 
-
-// BOOLEAN testingtypes(leftv res, leftv args)
-// {
-//   leftv u = args;
-//   if (u != NULL)
-//   {
-//     leftv v = u->next;
-//     if (v != NULL)
-//     {
-//       leftv w = v->next;
-//       if (w != NULL)
-//       {
-// 	Print("\n (u->Typ() ->) %d =?= %d (<-coneID) \n", u->Typ(),coneID);
-// 	Print("\n (u->Typ() ->) %d =?= %d (<-fanID) \n", v->Typ(),fanID);
-// 	Print("\n (u->Typ() ->) %d =?= %d (<-polytopeID) \n", w->Typ(),polytopeID);
-// 	res->rtyp = NONE;
-// 	res->data = NULL;
-// 	return FALSE;
-//       }
-//     }
-//   }
-//   return TRUE;
-// }
-
-
-// BOOLEAN testingintvec(leftv res, leftv args)
-// {
-//   leftv u = args;
-//   if ((u != NULL) && (u->Typ()==INTVEC_CMD))
-//   {
-//     intvec* iv = (intvec*)u->Data();
-//     polymake::Vector<polymake::Integer> pmvec = Intvec2PmVectorInteger(iv);
-//     res->rtyp = NONE;
-//     res->data = NULL;
-//     return FALSE;
-//   }
-//   return TRUE;
-// }
-
-
-// BOOLEAN testingfans(leftv res, leftv args)  // for testing purposes    
-// {                                           // creating a fan in polymake 
-//   leftv u = args;                           // and handing it to Singular
-//   if ((u != NULL) && (u->Typ() == fanID))
-//   {
-//     gfan::ZFan* zf = (gfan::ZFan*) u->Data();
-//     perl::Object pf = ZFan2PmFan(zf);
-//     gfan::ZFan* zff = new gfan::ZFan(PmFan2ZFan(&pf));
-//     res->rtyp = fanID;
-//     res->data = (char *)zff;
-//     return FALSE;
-//   }
-//   return TRUE;
-// }
-
-// BOOLEAN testingmatrices(leftv res, leftv args)
-// {
-//   leftv u = args;
-//   if ((u != NULL) && (u->Typ() == coneID))
-//     {
-//       gfan::ZCone* zc = (gfan::ZCone*) u->Data();
-//       gfan::ZMatrix zm = zc->getInequalities();
-//       polymake::Matrix<polymake::Integer> pm = GfZMatrix2PmMatrixInteger(&zm);
-//       gfan::ZMatrix zn = PmMatrixInteger2GfZMatrix(&pm);
-//       res->rtyp = NONE;
-//       res->data = NULL;
-//       return FALSE;
-//     }
-//   return TRUE;
-// }
-
-// BOOLEAN testingcones(leftv res, leftv args)  // for testing purposes       
-// {                                            // taking a cone from Singular,
-//                                              // handing it over to polymake 
-//                                              // and back                    
-//   leftv u = args;
-//   if ((u != NULL) && (u->Typ() == coneID))
-//     {
-//       gfan::ZCone* zc = (gfan::ZCone*) u->Data();
-//       Print("converting gfan cone to polymake cone...\n");
-//       polymake::perl::Object pc = ZCone2PmCone(zc);
-//       Print("converting polymake cone to gfan cone...\n");
-//       gfan::ZCone* zd = new gfan::ZCone(PmCone2ZCone(&pc));
-//       // res->rtyp = coneID;
-//       // res->data = (char *) zd;
-//       res->rtyp = NONE;
-//       res->data = NULL;
-//       return FALSE;
-//     }
-//   return TRUE;
-// }
-
-// BOOLEAN testingpolytopes(leftv res, leftv args) // for testing purposes
-// {                                                // taking a cone from Singular,
-//                                                  // handing it over to polymake
-//                                                  // and back
-//   leftv u = args;
-//   if ((u != NULL) && (u->Typ() == polytopeID))
-//   {
-//     gfan::ZCone* zp = (gfan::ZCone*) u->Data();
-//     polymake::perl::Object pp = ZPolytope2PmPolytope(zp);
-//     gfan::ZCone* zq = new gfan::ZCone(PmPolytope2ZPolytope(&pp));
-//     res->rtyp = polytopeID;
-//     res->data = (char *) zq;
-//     return FALSE;
-//   }
-//   return TRUE;
-// }   
-
-// BOOLEAN testingvisuals(leftv res, leftv args)   // for testing purposes
-// {                                               // testing visualization of fans
-//   try{                                          // exactly same as smalltest
-//     // perl::Object p("Polytope<Rational>");
-//     // p = CallPolymakeFunction("cube",3);
-//     perl::Object p("PolyhedralFan");
-//     Matrix<Integer> zm=(unit_matrix<Integer>(3));
-//     p.take("INPUT_RAYS") << zm;
-//     Set<int> s;
-//     s = s+0;
-//     s = s+1;
-//     s = s+2;
-//     Array<Set<int> > ar(1);
-//     ar[0]=s;
-//     p.take("INPUT_CONES") << ar;
-//     VoidCallPolymakeFunction("jreality",p.CallPolymakeMethod("VISUAL")); 
-//     res->rtyp = NONE;
-//     res->data = NULL;
-//     return FALSE;
-//   } 
-//   catch (const std::exception& ex) 
-//   {
-//     WerrorS("ERROR: "); WerrorS(ex.what()); WerrorS("\n"); 
-//     return TRUE;
-//   }
-// }
-
-
-// BOOLEAN testingstrings(leftv res, leftv args)
-// {
-//   leftv u = args;
-//   gfan::ZFan* zf = (gfan::ZFan*) u->Data();
-//   std::string zs = zf->toString();
-//   std::istringstream s(zs);
-//   gfan::ZFan* zg = new gfan::ZFan(s);
-//   res->rtyp = fanID;
-//   res->data = (char*) zg;
-//   return FALSE;
-// }
-
-
-// BOOLEAN callpolymakefunction(leftv res, leftv args)
-// {
-//   leftv u = args;
-//   if (u != NULL)
-//   {
-//     leftv v = u->next;
-//     if ((v != NULL) && (v->typ() == STRING_CMD))
-//     {
-//       /* checks for type of input, 
-//          stores it into a polymake::perl::Object */
-//       if (u->typ() == coneID)
-//       {
-//         gfan::ZCone* zc = (gfan::ZCone*) u->data();
-//         polymake::perl::Object in = ZCone2PmCone(zc);
-//       }
-//       if (u->typ() == fanID)
-//       {
-//         gfan::ZFan* zf = (gfan::ZFan*) u->data();
-//         polymake::perl::Object in = ZFan2PmFan(zf);
-//       }
-//       /* calls the functions in polymake */
-//       string cmd = v->data();
-//       polymake::perl::Object out;
-//       CallPolymakeFunction(cmd, in) >> out;
-//     }
-//   }
-// }
-
-
 BOOLEAN PMconeViaRays(leftv res, leftv args)
 {
   leftv u = args;
@@ -1881,17 +1682,6 @@ BOOLEAN PMpolytopeViaVertices(leftv res, leftv args)
   return TRUE;
 }
 
-
-// BOOLEAN loadPolymakeDocumentation(leftv res, leftv args)
-// {
-//   init_polymake_help();
-
-//   res->rtyp = NONE;
-//   res->data = NULL;
-//   return FALSE;
-// }
-
-
 extern "C" int mod_init(void* polymakesingular)
 {
   if (init_polymake==NULL) 
@@ -1899,7 +1689,7 @@ extern "C" int mod_init(void* polymakesingular)
   init_polymake->set_application("fan");
   // iiAddCproc("","cube",FALSE,cube);
   // iiAddCproc("","cross",FALSE,cross);
-  iiAddCproc("","coneViaRays",FALSE,PMconeViaRays);
+  iiAddCproc("","coneViaPoints",FALSE,PMconeViaRays);
   iiAddCproc("","polytopeViaVertices",FALSE,PMpolytopeViaVertices);
   iiAddCproc("","isLatticePolytope",FALSE,PMisLatticePolytope);
   iiAddCproc("","isBounded",FALSE,PMisBounded);

--- a/doc/cones.doc
+++ b/doc/cones.doc
@@ -187,6 +187,7 @@ c;
 * relativeInteriorPoint::
 * semigroupGenerator::
 * uniquePoint::
+* convexHull::
 * convexIntersection::
 * isFullSpace::
 * isOrigin::
@@ -441,7 +442,7 @@ codimension(c2);
 @end smallexample
 @end table
 @c --------------------------------------
-@node dimension,dual,codimension,cone related functions
+@node dimension,dualCone,codimension,cone related functions
 @subsubsection dimension
 @cindex dimension
 
@@ -469,13 +470,13 @@ dimension(c2);
 @end smallexample
 @end table
 @c --------------------------------------
-@node dual,equations,dimension,cone related functions
+@node dualCone,equations,dimension,cone related functions
 @subsubsection dual
 @cindex dual
 
 @table @code
 @item @strong{Syntax:}
-@code{dual(} cone c @code{)}
+@code{dualCone(} cone c @code{)}
 @item @strong{Type:}
 cone
 @item @strong{Purpose:}
@@ -487,21 +488,21 @@ intmat M1[2][2]=
 1,0,
 0,1;
 cone c1=coneViaPoints(M1);
-cone d1=dual(c1);
+cone d1=dualCone(c1);
 d1;
 print(rays(d1));
 intmat M2[2][2]=
 1,1,
 0,1;
 cone c2=coneViaPoints(M2);
-cone d2=dual(c2);
+cone d2=dualCone(c2);
 d2;
 print(rays(d2));
 @c example
 @end smallexample
 @end table
 @c --------------------------------------
-@node equations,facets,dual,cone related functions
+@node equations,facets,dualCone,cone related functions
 @subsubsection equations
 @cindex equations
 
@@ -947,17 +948,62 @@ uniquePoint(c2);
 @end smallexample
 @end table
 @c --------------------------------------
-@node convexIntersection,isFullSpace,uniquePoint,cone related functions
+@node convexHull,isFullSpace,convexIntersection,cone related functions
+@subsubsection convexHull
+@cindex convexHull
+
+@table @code
+@item @strong{Syntax:}
+@code{convexHull(} cone c1, cone c2 @code{)}
+@*@code{convexHull(} cone c1, polytope p1 @code{)}
+@*@code{convexHull(} polytope p1, cone c1 @code{)}
+@*@code{convexHull(} polytope p1, polytope p2 @code{)}
+@item @strong{Type:}
+cone if both input arguments are cones, else polytope
+@item @strong{Purpose:}
+the hull of the two objects
+@item @strong{Example:}
+@smallexample
+@c example
+intmat M1[2][2]=
+1,0,
+0,1;
+cone c1=coneViaPoints(M1);
+intmat M2[2][2]=
+1,1,
+1,-1;
+cone c2=coneViaPoints(M2);
+intmat M3[2][2]=
+1,0,
+0,-1;
+cone c3=coneViaPoints(M3);
+cone c12=convexHull(c1,c2);
+c12;
+print(rays(c12));
+cone c23=convexHull(c2,c3);
+c23;
+print(rays(c23));
+cone c13=convexHull(c1,c3);
+c13;
+print(rays(c13));
+@c example
+@end smallexample
+@end table
+@c --------------------------------------
+@node convexIntersection,convexHull,uniquePoint,cone related functions
 @subsubsection convexIntersection
 @cindex convexIntersection
 
 @table @code
 @item @strong{Syntax:}
 @code{convexIntersection(} cone c1, cone c2 @code{)}
+@*@code{convexIntersection(} cone c1, polytope p1 @code{)}
+@*@code{convexIntersection(} polytope p1, cone c1 @code{)}
+@*@code{convexIntersection(} polytope p1, polytope p2 @code{)}
 @item @strong{Type:}
-cone
+cone if both input arguments are cones, else polytope
 @item @strong{Purpose:}
-the intersection of the two cones
+the intersection of the two objects
 @item @strong{Example:}
 @smallexample
 @c example
@@ -1255,6 +1301,9 @@ See also @ref{ambientDimension},
 
 @menu
 * containsInCollection::
+* emptyFan::
+* fullFan::
+* fVector::
 * getCone::
 * insertCone::
 * isCompatible::
@@ -1263,7 +1312,7 @@ See also @ref{ambientDimension},
 * nmaxcones::
 * ncones::
 * numberOfConesOfDimension::
-* quickInsertCone::
+* removeCone::
 @end menu
 
 @c --------------------------------------------------------------------
@@ -1293,7 +1342,71 @@ containsInCollection(f,c);
 @end smallexample
 @end table
 @c --------------------------------------------------------------------
-@node getCone,insertCone,containsInCollection,fan related functions
+@node emptyFan,fullFan,containsInCollection,fan related functions
+@subsubsection emptyFan
+@cindex emptyFan
+
+@table @code
+@item @strong{Syntax:}
+@code{emptyFan(} int d @code{)}
+@item @strong{Type:}
+fan
+@item @strong{Purpose:}
+empty fan in ambient dimension d
+@item @strong{Example:}
+@smallexample
+@c example
+fan f=emptyFan(2);
+f;
+@c example
+@end smallexample
+@end table
+@c --------------------------------------------------------------------
+@node fullFan,fVector,emptyFan,fan related functions
+@subsubsection fullFan
+@cindex fullFan
+
+@table @code
+@item @strong{Syntax:}
+@code{fullFan(} int d @code{)}
+@item @strong{Type:}
+fan
+@item @strong{Purpose:}
+full fan in ambient dimension d
+@item @strong{Example:}
+@smallexample
+@c example
+fan f=fullFan(2);
+f;
+@c example
+@end smallexample
+@end table
+@c --------------------------------------------------------------------
+@node fVector,insertCone,fullFan,fan related functions
+@subsubsection fullFan
+@cindex fVector
+
+@table @code
+@item @strong{Syntax:}
+@code{fVector(} fan f @code{)}
+@item @strong{Type:}
+intvec
+@item @strong{Purpose:}
+F-Vector of the fan
+@item @strong{Example:}
+@smallexample
+@c example
+fan f=emptyFan(2);
+fVector(f);
+intmat M[2][2]=1,0,0,1;
+cone c=coneViaPoints(M);
+insertCone(f,c);
+fVector(f);
+@c example
+@end smallexample
+@end table
+@c --------------------------------------------------------------------
+@node getCone,insertCone,fVector,fan related functions
 @subsubsection getCone
 @cindex getCone
 
@@ -1328,10 +1441,11 @@ getCone(f,2,3,0,0);
 @table @code
 @item @strong{Syntax:}
 @code{insertCone(} fan f, cone c @code{)}
+@*@code{insertCone(} fan f, cone c, int check @code{)}
 @item @strong{Type:}
 none
 @item @strong{Purpose:}
-inserts the cone into the fan, checks for compatibility beforehand
+inserts the cone into the fan; checks for compatibility beforehand unless check is passed and equal 0
 @item @strong{Example:}
 @smallexample
 @c example
@@ -1525,7 +1639,7 @@ ncones(f);
 @end smallexample
 @end table
 @c --------------------------------------------------------------------
-@node numberOfConesOfDimension,quickInsertCone,ncones,fan related functions
+@node numberOfConesOfDimension,removeCone,ncones,fan related functions
 @subsubsection numberOfConesOfDimension
 @cindex numberOfConesOfDimension
 
@@ -1559,28 +1673,30 @@ numberOfConesOfDimension(f,3,0,1);
 @end smallexample
 @end table
 @c --------------------------------------------------------------------
-@node quickInsertCone,,numberOfConesOfDimension,fan related functions
-@subsubsection quickInsertCone
-@cindex quickInsertCone
+@node removeCone,,numberOfConesOfDimension,fan related functions
+@subsubsection removeCone
+@cindex removeCone
 
 @table @code
 @item @strong{Syntax:}
-@code{quickInsertCone(} fan f @code{)}
+@code{removeCone(} fan f, cone c @code{)}
+@*@code{removeCone(} fan f, cone c, int check @code{)}
 @item @strong{Type:}
 none
 @item @strong{Purpose:}
-inserts the cone into the fan, no checking of compatibility
+removes the cone from the fan; checks for compatibility beforehand unless check is passed and equal 0
 @item @strong{Example:}
 @smallexample
 @c example
-fan f=emptyFan(3);
-f;
-intmat M[3][3]=
-1,0,0,
-0,1,0,
-0,0,1;
+intmat M[2][2]=1,0,0,1;
+intmat N[2][2]=1,0,1,-1;
 cone c=coneViaPoints(M);
-quickInsertCone(f,c);
+cone d=coneViaPoints(N);
+fan f=emptyFan(2);
+insertCone(f,c);
+insertCone(f,d);
+f;
+removeCone(f,c);
 f;
 @c example
 @end smallexample
@@ -1694,11 +1810,56 @@ See also @ref{ambientDimension},
 @ref{setMultiplicity}.
 
 @menu
+* dualPolytope::
+* newtonPolytope::
 * vertices::
 @end menu
 
 @c --------------------------------------------------------------------
-@node vertices,,,polytope related functions
+@node dualPolytope,newtonPolytope,,polytope related functions
+@subsubsection dualPolytope
+@cindex dualPolytope
+
+@table @code
+@item @strong{Syntax:}
+@code{dualPolytope(} polytope p @code{)}
+@item @strong{Type:}
+polytope
+@item @strong{Purpose:}
+Newton polytope of f 
+@item @strong{Example:}
+@smallexample
+@c example
+intmat M[4][2]=
+0,0,
+1,0,
+0,1,
+1,1;
+polytope p=polytopeViaPoints(M);
+dualPolytope(p);
+@c example
+@c --------------------------------------------------------------------
+@node newtonPolytope,vertices,dualPolytope,polytope related functions
+@subsubsection newtonPolytope
+@cindex newtonPolytope
+
+@table @code
+@item @strong{Syntax:}
+@code{newtonpolytope(} poly f @code{)}
+@item @strong{Type:}
+polytope
+@item @strong{Purpose:}
+Newton polytope of f 
+@item @strong{Example:}
+@smallexample
+@c example
+ring r;
+poly f=x+y+z;
+polytope p=newtonPolytope(f);
+p;
+@c example
+@c --------------------------------------------------------------------
+@node vertices,,newtonPolytope,polytope related functions
 @subsubsection vertices
 @cindex vertices
 


### PR DESCRIPTION
removed makePolytope
an extra function to convert a cone into a polytope is unnecessary,
will write a cast for that in the future

removed scalePolytope
an extra function to scale a polytope is unnecessary,
since one can just write p*k, p polytope, k integer.

removed isComplete
this is not working as expected (gfanlib problems),
should user need such a functionality,
he/she needs to resort to the polymake interface.

changed insertCone/removeCone
input is checked for compatibility by default,
should the user wish to circumvent this check (which is slow)
the user needs to pass an extra int argument which is 0.

removed various chunks of code that were commented out
