### PR TITLE
Make debuging objects (_g) a configure option.

### DIFF
--- a/Singular/Makefile.am
+++ b/Singular/Makefile.am
@@ -19,7 +19,13 @@ AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir} -I${top_srcdir}/numeric -I${top_
 
 ########################### libSingular* #########################
 
-libSingular_LTLIBRARIES = libSingular.la libSingular_g.la
+if WANT_DEBUG
+  LIB_G=libSingular_g.la
+else
+  LIB_G=
+endif
+
+libSingular_LTLIBRARIES = libSingular.la ${LIB_G}
 libSingulardir = $(libdir)/singular
 
 libSingular_la_CFLAGS   = -O3 -fomit-frame-pointer -Wextra -Wall -Wno-long-long ${PIPE}  $(WARNCFLAGS)
@@ -181,13 +187,21 @@ feOptTS_CPPFLAGS = ${AM_CPPFLAGS} -DHAVE_CONFIG_H -DNDEBUG -DOM_NDEBUG -DTSINGUL
 
 ########################### Singular* #########################
 
-EXTRA_PROGRAMS = Singulard Singulardg libparse
+if WANT_DEBUG
+  EXTRA_PROGRAMS = Singulard Singulardg libparse
+else
+  EXTRA_PROGRAMS = Singulard libparse
+endif
 
 # the "optional_programs" variable should be defined in the configure
 # script, and listed in an AC_SUBST macro
 optional_Singular_programs = 
 
-bin_PROGRAMS = Singular Singularg ESingular TSingular $(optional_Singular_programs)
+if WANT_DEBUG
+  bin_PROGRAMS = Singular Singularg ESingular TSingular $(optional_Singular_programs)
+else
+  bin_PROGRAMS = Singular ESingular TSingular $(optional_Singular_programs)
+endif
 
 AMLDFLAGS = -L${abs_top_builddir}/Singular -L${abs_top_builddir}/numeric -L${abs_top_builddir}/kernel -L${abs_top_builddir}/libpolys/polys  -L${top_builddir}/libpolys/coeffs -L${top_builddir}/libpolys/reporter -L${top_builddir}/libpolys/misc $(USE_FACTORY) -L${abs_top_builddir}/omalloc -L${abs_top_builddir}/findexec
 

--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,13 @@ if test "x$ENABLE_FACTORY" = xyes; then
  fi
 fi
 
+AC_ARG_ENABLE(debug, AS_HELP_STRING([--disable-debug], [do NOT build the debugging version of the libraries]),
+ [if test "x$enableval"  = "xyes"; then
+   ENABLE_DEBUG=yes
+ fi], ENABLE_DEBUG=no)
+
+AM_CONDITIONAL(WANT_DEBUG, test x"${ENABLE_DEBUG}" == xyes)
+
 AC_CONFIG_SUBDIRS([findexec]) 
 AC_CONFIG_SUBDIRS([omalloc])
 

--- a/factory/Makefile.am
+++ b/factory/Makefile.am
@@ -8,7 +8,13 @@ CXXTEMPLFLAGS=
 
 AM_CPPFLAGS = -I${builddir}/include -I${srcdir}/include $(FLINT_CFLAGS) ${GMP_CFLAGS} ${NTL_CFLAGS} ${OMALLOC_CFLAGS}
 
-lib_LTLIBRARIES = libfactory.la libfactory_g.la
+if WANT_DEBUG
+  LIB_G=libfactory_g.la
+else
+  LIB_G=
+endif
+
+lib_LTLIBRARIES = libfactory.la ${LIB_G}
 
 libfactory_la_CXXFLAGS   = -O3 -fomit-frame-pointer ${CXXTEMPLFLAGS}
 libfactory_la_LIBADD     = ${abs_builddir}/libfac/libfac.la $(FLINT_LIBS) ${GMP_LIBS} ${NTL_LIBS}

--- a/factory/configure.ac
+++ b/factory/configure.ac
@@ -90,6 +90,13 @@ AC_ARG_ENABLE(
   ,
   enable_debugoutput=no)
 
+AC_ARG_ENABLE(debug, AS_HELP_STRING([--disable-debug], [do NOT build the debugging version of the libraries]),
+ [if test "x$enableval"  = "xyes"; then
+   ENABLE_DEBUG=yes
+ fi], ENABLE_DEBUG=no)
+
+AM_CONDITIONAL(WANT_DEBUG, test x"${ENABLE_DEBUG}" == xyes)
+
 #
 # - check for CC and CXX but be careful about CFLAGS.
 #

--- a/factory/libfac/Makefile.am
+++ b/factory/libfac/Makefile.am
@@ -1,4 +1,10 @@
-noinst_LTLIBRARIES=libfac.la libfac_g.la
+if WANT_DEBUG
+  LIB_G=libfac_g.la
+else
+  LIB_G=
+endif
+
+noinst_LTLIBRARIES=libfac.la ${LIB_G}
 
 CXXTEMPLFLAGS =  ## -fno-implicit-templates
 

--- a/findexec/Makefile.am
+++ b/findexec/Makefile.am
@@ -1,6 +1,12 @@
 ACLOCAL_AMFLAGS = -I ../m4
 
-libfindexec_LTLIBRARIES = libfindexec.la libfindexec_g.la
+if WANT_DEBUG
+  LIB_G=libfindexec_g.la
+else
+  LIB_G=
+endif
+
+libfindexec_LTLIBRARIES = libfindexec.la ${LIB_G}
 libfindexecdir = $(libdir)/singular
 
 CXXTEMPLFLAGS = 

--- a/findexec/configure.ac
+++ b/findexec/configure.ac
@@ -57,6 +57,13 @@ LT_INIT
 
 SING_CHECK_PIPE
 
+AC_ARG_ENABLE(debug, AS_HELP_STRING([--disable-debug], [do NOT build the debugging version of the libraries]),
+ [if test "x$enableval"  = "xyes"; then
+   ENABLE_DEBUG=yes
+ fi], ENABLE_DEBUG=no)
+
+AM_CONDITIONAL(WANT_DEBUG, test x"${ENABLE_DEBUG}" == xyes)
+
 
 # CFLAGS
 if test "x$GCC" = xyes && test "x$cflags_expl_set" = xno; then

--- a/kernel/Makefile.am
+++ b/kernel/Makefile.am
@@ -11,7 +11,13 @@
 
 CXXTEMPLFLAGS = ## -fno-implicit-templates
 
-libkernel_LTLIBRARIES = libkernel.la libkernel_g.la
+if WANT_DEBUG
+  LIB_G=libkernel_g.la
+else
+  LIB_G=
+endif
+
+libkernel_LTLIBRARIES = libkernel.la ${LIB_G}
 libkerneldir = $(libdir)/singular
 
 libkernel_la_CFLAGS   = -O3 -fomit-frame-pointer -Wextra -Wall -Wno-long-long ${PIPE}

--- a/libpolys/coeffs/Makefile.am
+++ b/libpolys/coeffs/Makefile.am
@@ -3,7 +3,13 @@ CXXTEMPLFLAGS =
 
 AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/.. -I${top_builddir} -I${top_builddir}/.. -I${srcdir} -I${top_srcdir}/../factory/include -I${top_builddir}/../factory/include ${FACTORY_CFLAGS} ${GMP_CFLAGS} ${NTL_CFLAGS}
 
-lib_LTLIBRARIES = libcoeffs.la libcoeffs_g.la
+if WANT_DEBUG
+  LIB_G=libcoeffs_g.la
+else
+  LIB_G=
+endif
+
+lib_LTLIBRARIES = libcoeffs.la ${LIB_G}
 libcoeffsdir = $(libdir)/singular
 
 libcoeffs_la_CFLAGS   = -O3 -fomit-frame-pointer ${PIPE}

--- a/libpolys/configure.ac
+++ b/libpolys/configure.ac
@@ -114,6 +114,13 @@ else
   PREFIX="$ac_default_prefix"
 fi
 
+AC_ARG_ENABLE(debug, AS_HELP_STRING([--disable-debug], [do NOT build the debugging version of the libraries]),
+ [if test "x$enableval"  = "xyes"; then
+   ENABLE_DEBUG=yes
+ fi], ENABLE_DEBUG=no)
+
+AM_CONDITIONAL(WANT_DEBUG, test x"${ENABLE_DEBUG}" == xyes)
+
 # AC_SUBST(PREFIX)
 AC_DEFINE_UNQUOTED(INSTALL_PREFIX,"$PREFIX",Prefix)
 

--- a/libpolys/misc/Makefile.am
+++ b/libpolys/misc/Makefile.am
@@ -3,7 +3,13 @@ CXXTEMPLFLAGS      =
 
 AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/.. -I${top_builddir} -I${top_builddir}/..
 
-lib_LTLIBRARIES = libmisc.la libmisc_g.la
+if WANT_DEBUG
+  LIB_G=libmisc_g.la
+else
+  LIB_G=
+endif
+
+lib_LTLIBRARIES = libmisc.la ${LIB_G}
 libmiscdir = $(libdir)/singular
 
 libmisc_la_CFLAGS   = -O3 -fomit-frame-pointer ${PIPE}

--- a/libpolys/polys/Makefile.am
+++ b/libpolys/polys/Makefile.am
@@ -26,7 +26,15 @@ else
   USE_P_PROCS_DYNAMIC_CC =
 endif
 
-libpolys_LTLIBRARIES = libpolys.la libpolys_g.la
+if WANT_DEBUG
+  LIB_G=libpolys_g.la
+  MOD_G=p_Procs_FieldGeneral_g.la p_Procs_FieldIndep_g.la p_Procs_FieldQ_g.la p_Procs_FieldZp_g.la
+else
+  LIB_G=
+  MOD_G=
+endif
+
+libpolys_LTLIBRARIES = libpolys.la ${LIB_G}
 libpolysdir = $(libdir)/singular
 
 SOURCES = \
@@ -116,8 +124,7 @@ moduledir = $(bindir)
 #moduledir = $(libexecdir)/singular/MOD/
 
 if ENABLE_P_PROCS_DYNAMIC
-  module_LTLIBRARIES=p_Procs_FieldGeneral.la p_Procs_FieldIndep.la p_Procs_FieldQ.la p_Procs_FieldZp.la \
-                     p_Procs_FieldGeneral_g.la p_Procs_FieldIndep_g.la p_Procs_FieldQ_g.la p_Procs_FieldZp_g.la
+  module_LTLIBRARIES=p_Procs_FieldGeneral.la p_Procs_FieldIndep.la p_Procs_FieldQ.la p_Procs_FieldZp.la ${MOD_G}
 endif
 
 libpolys_includedir=$(includedir)/singular/polys

--- a/libpolys/reporter/Makefile.am
+++ b/libpolys/reporter/Makefile.am
@@ -3,7 +3,13 @@ CXXTEMPLFLAGS =
 
 AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/.. -I${top_builddir} -I${top_builddir}/..
 
-lib_LTLIBRARIES = libreporter.la libreporter_g.la
+if WANT_DEBUG
+  LIB_G=libreporter_g.la
+else
+  LIB_G=
+endif
+
+lib_LTLIBRARIES = libreporter.la ${LIB_G}
 libreporterdir = $(libdir)/singular
 
 libreporter_la_CFLAGS   = -O3 -fomit-frame-pointer ${PIPE}

--- a/numeric/Makefile.am
+++ b/numeric/Makefile.am
@@ -1,4 +1,10 @@
-libnumeric_LTLIBRARIES = libnumeric.la libnumeric_g.la
+if WANT_DEBUG
+  LIB_G=libnumeric_g.la
+else
+  LIB_G=
+endif
+
+libnumeric_LTLIBRARIES = libnumeric.la ${LIB_G}
 libnumericdir = $(libdir)/singular
 
 CXXTEMPLFLAGS =  ## -fno-implicit-templates

--- a/omalloc/Makefile.am
+++ b/omalloc/Makefile.am
@@ -1,6 +1,12 @@
 ACLOCAL_AMFLAGS = -I ../m4
 
-lib_LTLIBRARIES=libomalloc.la libomalloc_g.la
+if WANT_DEBUG
+  LIB_G=libomalloc_g.la
+else
+  LIB_G=
+endif
+
+lib_LTLIBRARIES=libomalloc.la ${LIB_G}
 
 libomalloc_includedir=$(includedir)/omalloc
 

--- a/omalloc/configure.ac
+++ b/omalloc/configure.ac
@@ -23,6 +23,13 @@ AC_SUBST(VERSION)
 dnl lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll
 dnl help for configure
 dnl
+AC_ARG_ENABLE(debug, AS_HELP_STRING([--disable-debug], [do NOT build the debugging version of the libraries]),
+ [if test "x$enableval"  = "xyes"; then
+   ENABLE_DEBUG=yes
+ fi], ENABLE_DEBUG=no)
+
+AM_CONDITIONAL(WANT_DEBUG, test x"${ENABLE_DEBUG}" == xyes)
+
 AC_ARG_WITH(
   external-config_h,
   [ --with-external-config_h=HEADER_FILE

--- a/xalloc/Makefile.am
+++ b/xalloc/Makefile.am
@@ -1,6 +1,12 @@
 ACLOCAL_AMFLAGS = -I ../m4
 
-libomalloc_LTLIBRARIES=libomalloc.la libomalloc_g.la
+if WANT_DEBUG
+  LIB_G=libomalloc_g.la
+else
+  LIB_G=
+endif
+
+libomalloc_LTLIBRARIES=libomalloc.la ${LIB_G}
 libomallocdir = $(libdir)/
 
 libomalloc_includedir=$(includedir)/omalloc


### PR DESCRIPTION
This series of patches to configure.ac and Makefile.am files to make the compilation and installation of debuging objects. The option is --enable-debug and the default is to not create the debuging objects.
