### PR TITLE
Avoid multiple initialization  of 'shared' and 'reference' types

### DIFF
--- a/Singular/countedref.cc
+++ b/Singular/countedref.cc
@@ -721,6 +721,9 @@ BOOLEAN countedref_deserialize(blackbox **b, void **d, si_link f)
 
 void countedref_reference_load()
 {
+  static bool loaded = false;
+  if (loaded) return;
+
   blackbox *bbx = (blackbox*)omAlloc0(sizeof(blackbox));
   bbx->blackbox_CheckAssign = countedref_CheckAssign;
   bbx->blackbox_destroy = countedref_destroy;
@@ -737,10 +740,14 @@ void countedref_reference_load()
   bbx->blackbox_deserialize = countedref_deserialize;
   bbx->data             = omAlloc0(newstruct_desc_size());
   setBlackboxStuff(bbx, "reference");
+  loaded = true;
 }
 
 void countedref_shared_load()
 {
+  static bool loaded = false;
+  if (loaded) return;
+
   blackbox *bbxshared = (blackbox*)omAlloc0(sizeof(blackbox));
   bbxshared->blackbox_String  = countedref_String;
   bbxshared->blackbox_Print  = countedref_Print;
@@ -758,4 +765,6 @@ void countedref_shared_load()
   bbxshared->blackbox_Init    = countedref_InitShared;
   bbxshared->data             = omAlloc0(newstruct_desc_size());
   setBlackboxStuff(bbxshared, "shared");
+
+  loaded = true;
 }

--- a/Tst/Short/countedref_s.tst
+++ b/Tst/Short/countedref_s.tst
@@ -1165,6 +1165,23 @@ attrib(I, "isSB");
 
 attrib(ref2, "isSB");
 
+shared shval= I;
+// Ensure reloading does not damage something
+system("reference"); 
+system("shared");
+reference refTwo = ref2;
+shared shval2 = shval;
+refTwo;
+shval2[1] == shval[1];
+kill refTwo, shval2;
+system("reference"); 
+system("shared");
+reference refTwo = ref2;
+shared shval2 = shval;
+refTwo;
+shval2[1] == shval[1];
+kill refTwo, shval2;
+
 // --------------------------------------------------------
 tst_status(1);$
 


### PR DESCRIPTION
Since  'shared' and 'reference' types are deactivated by default, one has to ensure via
`system("shared")` or `system("reference")` that the command is available. Previously multiple calls would have generated (possible incompatible) types of the same name (and with the same properties though). The patch avoids that problem. The types are initialized only once.
