### PR TITLE
Using blackbox-functionality to check whther type was already loaded

### DIFF
--- a/Singular/countedref.cc
+++ b/Singular/countedref.cc
@@ -721,8 +721,9 @@ BOOLEAN countedref_deserialize(blackbox **b, void **d, si_link f)
 
 void countedref_reference_load()
 {
-  static bool loaded = false;
-  if (loaded) return;
+  int tok;
+  if (blackboxIsCmd("reference", tok) == ROOT_DECL)
+    return;
 
   blackbox *bbx = (blackbox*)omAlloc0(sizeof(blackbox));
   bbx->blackbox_CheckAssign = countedref_CheckAssign;
@@ -740,13 +741,13 @@ void countedref_reference_load()
   bbx->blackbox_deserialize = countedref_deserialize;
   bbx->data             = omAlloc0(newstruct_desc_size());
   setBlackboxStuff(bbx, "reference");
-  loaded = true;
 }
 
 void countedref_shared_load()
 {
-  static bool loaded = false;
-  if (loaded) return;
+  int tok;
+  if (blackboxIsCmd("shared", tok) == ROOT_DECL)
+    return;
 
   blackbox *bbxshared = (blackbox*)omAlloc0(sizeof(blackbox));
   bbxshared->blackbox_String  = countedref_String;
@@ -765,6 +766,4 @@ void countedref_shared_load()
   bbxshared->blackbox_Init    = countedref_InitShared;
   bbxshared->data             = omAlloc0(newstruct_desc_size());
   setBlackboxStuff(bbxshared, "shared");
-
-  loaded = true;
 }


### PR DESCRIPTION
This patch utilize blackboxIsCmd to check whther `shared` and`reference` were already activated. (Instead of static bool markers.)
