### PR TITLE
Ignoring modules reloading

### DIFF
--- a/Singular/iplib.cc
+++ b/Singular/iplib.cc
@@ -1104,6 +1104,10 @@ BOOLEAN load_modules(char *newlib, char *fullname, BOOLEAN autoexport)
       goto load_modules_end;
     }
   }
+  if (dynl_check_opened(FullName)) {
+    if (BVERBOSE(V_LOAD_LIB)) Warn( "%s already loaded", fullname);
+    return FALSE;
+  }
   if((IDPACKAGE(pl)->handle=dynl_open(FullName))==(void *)NULL)
   {
     Werror("dynl_open failed:%s", dynl_error());
@@ -1148,13 +1152,18 @@ BOOLEAN load_builtin(char *newlib, BOOLEAN autoexport, SModulFunc_t init)
   char *plib = iiConvName(newlib);
 
   pl = IDROOT->get(plib,0);
-  if (pl==NULL)
+  if (pl!=NULL)
   {
-    pl = enterid( plib,0, PACKAGE_CMD, &IDROOT,
-                  TRUE );
-    IDPACKAGE(pl)->language = LANG_C;
-    IDPACKAGE(pl)->libname=omStrDup(newlib);
+    if (BVERBOSE(V_LOAD_LIB)) Warn( "(builtin) %s already loaded", newlib);
+    omFree(plib);
+    return FALSE;
   }
+
+  pl = enterid( plib,0, PACKAGE_CMD, &IDROOT,
+                TRUE );
+  IDPACKAGE(pl)->language = LANG_C;
+  IDPACKAGE(pl)->libname=omStrDup(newlib);
+
   IDPACKAGE(pl)->handle=(void *)NULL;
   SModulFunctions sModulFunctions;
 

--- a/kernel/mod_raw.cc
+++ b/kernel/mod_raw.cc
@@ -4,7 +4,8 @@
 /*
  * ABSTRACT: machine depend code for dynamic modules
  *
- * Provides: dynl_open()
+ * Provides: dynl_check_opened()
+ *           dynl_open()
  *           dynl_sym()
  *           dynl_error()
  *           dynl_close()
@@ -207,6 +208,13 @@ extern "C" {
 #include <dlfcn.h>
 
 static void* kernel_handle = NULL;
+int dynl_check_opened(
+  char *filename    /* I: filename to check */
+  )
+{
+  return dlopen(filename,RTLD_NOW|RTLD_NOLOAD) != NULL;
+}
+
 void *dynl_open(
   char *filename    /* I: filename to load */
   )
@@ -250,6 +258,18 @@ const char *dynl_error()
 #include <dl.h>
 
 typedef char *((*func_ptr) ());
+
+int dynl_check_opened(    /* NOTE: untested */
+  char *filename    /* I: filename to check */
+  )
+{
+  struct shl_descriptor *desc;
+  for (int idx = 0; shl_get(idx, &desc) != -1; ++idx)
+  {
+    if (strcmp(filename, desc->filename) == 0) return TRUE;
+  }
+  return FALSE;
+}
 
 void *dynl_open(char *filename)
 {
@@ -314,6 +334,11 @@ const char *dynl_error()
  * SECTION generic: dynamic madules not available
  *****************************************************************************/
 #ifdef DL_NOT_IMPLEMEMENTED
+
+int dynl_check_opened(char *filename)
+{
+  return FALSE;
+}
 
 void *dynl_open(char *filename)
 {

--- a/kernel/mod_raw.h
+++ b/kernel/mod_raw.h
@@ -1,3 +1,4 @@
+
 #ifndef MOD_RAW_H
 #define MOD_RAW_H
 /****************************************
@@ -6,7 +7,8 @@
 /*
  * ABSTRACT: machine depend code for dynamic modules
  *
- * Provides: dynl_open()
+ * Provides: dynl_check_opened()
+ *           dynl_open()
  *           dynl_sym()
  *           dynl_error()
  *           dunl_close()
@@ -25,6 +27,7 @@ void* dynl_sym_warn(void* handle, const char* proc, const char* msg = NULL );
 #ifdef __cplusplus
 extern "C" {
 #endif
+int          dynl_check_opened(char* filename);
 void *       dynl_open(char *filename);
 // if handle == DYNL_KERNEL_HANDLE, then symbol is searched for
 // in kernel of program
@@ -46,7 +49,8 @@ const char * dynl_error();
 #define SI_BUILTIN_PYOBJECT(add) 
 #endif
 
-/// Use @c add(name) to add built-in library to macro
+/// Data for @c type_of_LIB to determine built-in modules,
+/// use @c add(name) to add built-in library to macro
 #define SI_FOREACH_BUILTIN(add)\
   add(huhu)\
   SI_BUILTIN_PYOBJECT(add)


### PR DESCRIPTION
This commit allows calling `LIB("file.so");` multiple times.

Note, we also added dynl_check_opened (untested for HPUX).
