### PR TITLE
Fix: avoid infinite recursion, if pyobject.so is broken

### DIFF
--- a/Singular/pyobject_setup.cc
+++ b/Singular/pyobject_setup.cc
@@ -32,7 +32,8 @@ static BOOLEAN pyobject_load()
 void* pyobject_autoload(blackbox* bbx)
 {
   assume(bbx != NULL);
-  return (pyobject_load()? NULL: bbx->blackbox_Init(bbx));
+  return (pyobject_load() || (bbx->blackbox_Init == pyobject_autoload)? 
+	  NULL: bbx->blackbox_Init(bbx));
 }
 
 void pyobject_default_destroy(blackbox  *b, void *d)


### PR DESCRIPTION
Backporting a fix for the autoloading of the pyobject blackbox type.
