### PR TITLE
Fix for Cygwin

### DIFF
--- a/Singular/Makefile.in
+++ b/Singular/Makefile.in
@@ -541,7 +541,7 @@ Singular_res.o: Singular.rc
 
 ## run
 run.o: run.c run.h
-	gcc -c -I. -O2 run.c -o run.o
+	gcc -c -I. -O2 run.c -o run.o -I..
 
 runTSingular : run.o TSingular_res.o
 	gcc -mwindows run.o TSingular_res.o -o runTSingular.exe


### PR DESCRIPTION
 Could not compile Singular on Cygwin with GCC 4.5.3 without this change that Oleksandr suggested.
