### PR TITLE
chg: removed 'extern "C"' around declaration of feOptHelp and feGetOptValue

### DIFF
--- a/Singular/feOpt.h
+++ b/Singular/feOpt.h
@@ -32,17 +32,12 @@ typedef enum {FE_OPT_UNDEF}  feOptIndex;
 #endif
 
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 void feOptHelp(const char* name);
 
 void* feGetOptValue(feOptIndex opt);
 
 
 #ifdef __cplusplus
-}
 
 inline void* feOptValue(feOptIndex opt)
 {


### PR DESCRIPTION
proposed fix from Hans
declaring functions as C functions caused some problems during the compilation
on cygwin systems because certain object files expected them to be c++ functions
unsure why they were declared as C functions to begin with
