### PR TITLE
regres.cmd: print diff info only for verbose levels >1

### DIFF
--- a/Tst/regress.cmd
+++ b/Tst/regress.cmd
@@ -748,7 +748,7 @@ sub tst_check
         $exit_status = Diff($root);
         if ($exit_status)
         {
-	  unless ($verbosity < 3)
+	  unless ($verbosity < 2)
 	  {
 	    print "\n";
 	    mysystem("$cat \"$root.diff\"");
@@ -1218,7 +1218,7 @@ foreach (@ARGV)
     close (LST_FILE);
       
     printf("$base Summary: Checks:$lst_checks Failed:%d Time:%.2f\n", $lst_checks - $lst_checks_pass, $lst_used_time)
-      unless ($verbosity < 2);
+      unless ($verbosity < 1);
       
     tcLog( sprintf("list '$base' Summary: Checks:$lst_checks Failed:%d Time:%.2f", $lst_checks - $lst_checks_pass, $lst_used_time) );
     blockClosed ($b);
@@ -1235,7 +1235,7 @@ foreach (@ARGV)
   }
 }
 
-unless ($verbosity < 2 || $lst_checks == $total_checks)
+unless ($verbosity < 1 || $lst_checks == $total_checks)
 {
   printf("Summary: Checks:$total_checks Failed:%d Time:%.2f\n", $total_checks - $total_checks_pass, $total_used_time);
 }


### PR DESCRIPTION
 When running 'regress.cmd' for a couple of tests,
verbosity level 1 or even better 2 is necessary to to observe the progress of the test.

At the same time, in case of errors, the difference output is printed for verbosity level>0
That output makes it hard to follow the test progress immediately and distinguish failed tests from succeeded ones .

Proposal:

print diff output only for verbosity level >1
