### PR TITLE
Fix to allow external code to use libsingular

### DIFF
--- a/Singular/libsingular.h
+++ b/Singular/libsingular.h
@@ -7,7 +7,7 @@
 #include <kernel/structs.h>
 #include <kernel/polys.h>
 #include <coeffs/numbers.h>
-#include <libpolys/coeffs/longrat.h>
+#include <coeffs/longrat.h>
 #include <kernel/febase.h>
 #include <polys/monomials/ring.h>
 #include <omalloc/omalloc.h>


### PR DESCRIPTION
Without this change, it is impossible to link a 3rd party tools (such as the libsing GAP package) against a version of libsingular installed via "make install", as no "libpolys" directory is installed.
