### PR TITLE
Fixed name conflict INT64 and wrong type

### DIFF
--- a/factory/ChangeLog
+++ b/factory/ChangeLog
@@ -190,7 +190,7 @@ Wed Jun 03 14:47:41 1998    <pohl@FUECHSE>
 
 Mon May 11 11:36:22 1998  Jens Schmidt  <schmidt@mathematik.uni-kl.de>
 
-	* config.h.in (INT64): unused declarations for MetroWerks removed
+	* config.h.in (FACTORY_INT64): unused declarations for MetroWerks removed
 
 	* imm.cc (imm_mul): wrapped by `#ifdef __MWERKS__'
 
@@ -228,7 +228,7 @@ Tue Apr 14 14:05:47 1998  Wilfred Pohl  <pohl@mathematik.uni-kl.de>
 	* fac_univar.cc (UnivariateQuadraticLift): type for `log()' must
 	  be float, hence constant `2' replaced by `2.0'
 
-	* config.h.in (INT64): new typedef for Metroworks compiler
+	* config.h.in (FACTORY_INT64): new typedef for Metroworks compiler
 
 Mon Apr  6 14:06:49 MET DST 1998  Jens Schmidt
 
@@ -570,7 +570,7 @@ Tue Dec  9 10:03:07 1997  Jens Schmidt  <schmidt@mathematik.uni-kl.de>
 	  (dist): creates directory `winnt/'
 	  (distfiles): `bin/makeheader.pl' added to distribution
 
-	* config.h.in (INT64): new define
+	* config.h.in (FACTORY_INT64): new define
 
 	* bin/makeheader.pl: new file
 
@@ -598,18 +598,18 @@ Thu Nov 27 21:00:00 1997  Ruediger Stobbe  <rstobbe@de.oracle.com>
 	* winnt/factory.h: for the first time this file is a hand-made
 	  version of factory.h for Windows NT
 
-	* config.h.in: new typedef INT64 for 64 bit integer type of various
+	* config.h.in: new typedef FACTORY_INT64 for 64 bit integer type of various
 	  platforms (currently 'long long int' for gcc and '__int64' for
 	  MS VC++)
 
 	* readcf.y: malloc.h and memory.h are included in the case of WINNT
 	  to have prototypes for alloca and memcpy
 
-	* ffops.h: now uses INT64 instead of long long int
+	* ffops.h: now uses FACTORY_INT64 instead of long long int
 
-	* ffops.cc: now uses INT64 instead of long long int
+	* ffops.cc: now uses FACTORY_INT64 instead of long long int
 
-	* imm.h: now uses INT64 instead of long long int
+	* imm.h: now uses FACTORY_INT64 instead of long long int
 
 	* int_poly.cc: includes strstrea.h instead of strstream.h in the
 	  case of WINNT (a typical Microsoft 8.3 problem - its a pity)

--- a/factory/config.h.in.cmake
+++ b/factory/config.h.in.cmake
@@ -84,7 +84,7 @@
 #cmakedefine DEBUGOUTPUT 1
 
 /* define type of your compilers 64 bit integer type */
-#define INT64 long long int
+#define FACTORY_INT64 long long int
 
 #cmakedefine HAVE_NTL 1
 

--- a/factory/configure.ac
+++ b/factory/configure.ac
@@ -106,9 +106,9 @@ AC_ARG_ENABLE(
   ,
   enable_debugoutput=no)
 
-AH_TEMPLATE([INT64], [Defenition for INT64])
+AH_TEMPLATE([FACTORY_INT64], [Defenition for FACTORY_INT64])
 # Always long long int???!
-AC_DEFINE([INT64], [long long int]) 
+AC_DEFINE([FACTORY_INT64], [long long int]) 
 
 DX_INIT_DOXYGEN($PACKAGE_NAME, MYDOXYGENCONFIG)
 

--- a/factory/facAbsBiFact.cc
+++ b/factory/facAbsBiFact.cc
@@ -415,7 +415,7 @@ differentevalpoint:
     nmod_poly_factor_insert (nmodFactors, FLINTFpi, 1L);
     nmod_poly_factor_insert (nmodFactors, FLINTGpi, 1L);
 
-    long * link= new long [2];
+    slong * link= new slong [2];
     fmpz_poly_t *v= new fmpz_poly_t[2];
     fmpz_poly_t *w= new fmpz_poly_t[2];
     fmpz_poly_init(v[0]);

--- a/factory/ffops.h
+++ b/factory/ffops.h
@@ -11,8 +11,8 @@
 #endif
 
 /* define type of your compilers 64 bit integer type */
-#ifndef INT64
-#define INT64 long long int
+#ifndef FACTORY_INT64
+#define FACTORY_INT64 long long int
 #endif
 
 extern int ff_prime;
@@ -76,9 +76,9 @@ inline int ff_longnorm ( const long a )
 #endif
 }
 
-inline int ff_bignorm ( const INT64 a )
+inline int ff_bignorm ( const FACTORY_INT64 a )
 {
-    int n = (int)(a % (INT64)ff_prime);
+    int n = (int)(a % (FACTORY_INT64)ff_prime);
 #if defined(i386) || defined(NTL_AVOID_BRANCHING)
     n += (n >> 31) & ff_prime;
     return n;
@@ -133,7 +133,7 @@ inline int ff_neg ( const int a )
 inline int ff_mul ( const int a, const int b )
 {
     if ( ff_big )
-        return ff_bignorm( (INT64)a * (INT64)b );
+        return ff_bignorm( (FACTORY_INT64)a * (FACTORY_INT64)b );
     else
         return ff_longnorm ( (long)a * (long)b );
 }

--- a/factory/imm.h
+++ b/factory/imm.h
@@ -32,8 +32,8 @@ const long FFMARK = 2;
 const long GFMARK = 3;
 
 /* define type of your compilers 64 bit integer type */
-#ifndef INT64
-#define INT64 long long int
+#ifndef FACTORY_INT64
+#define FACTORY_INT64 long long int
 #endif
 
 #if SIZEOF_LONG == 4
@@ -45,11 +45,11 @@ const long MAXIMMEDIATE = (1L<<60)-2L;  // 2^60-2
 #endif
 
 #if defined(WINNT) && ! defined(__GNUC__)
-const INT64 MINIMMEDIATELL = -268435454i64;
-const INT64 MAXIMMEDIATELL = 268435454i64;
+const FACTORY_INT64 MINIMMEDIATELL = -268435454i64;
+const FACTORY_INT64 MAXIMMEDIATELL = 268435454i64;
 #else
-const INT64 MINIMMEDIATELL = -268435454LL;
-const INT64 MAXIMMEDIATELL = 268435454LL;
+const FACTORY_INT64 MINIMMEDIATELL = -268435454LL;
+const FACTORY_INT64 MAXIMMEDIATELL = 268435454LL;
 #endif
 
 //{{{ conversion functions
@@ -302,30 +302,30 @@ imm_mul ( InternalCF * lhs, InternalCF * rhs )
     long a = imm2int( lhs );
     long b = imm2int( rhs );
     int sa= 1;
-    unsigned INT64 aa, bb;
+    unsigned FACTORY_INT64 aa, bb;
     if (a < 0)
     {
       sa= -1;
-      aa= (unsigned INT64) (-a);
+      aa= (unsigned FACTORY_INT64) (-a);
     }
     else
-      aa= (unsigned INT64) a;
+      aa= (unsigned FACTORY_INT64) a;
     if (b < 0)
     {
       sa= -sa;
-      bb= (unsigned INT64) (-b);
+      bb= (unsigned FACTORY_INT64) (-b);
     }
     else
-      bb= (unsigned INT64) b;
-    unsigned INT64 result = aa*bb;
+      bb= (unsigned FACTORY_INT64) b;
+    unsigned FACTORY_INT64 result = aa*bb;
     #if SIZEOF_LONG == 4
-    if (result>(unsigned INT64)MAXIMMEDIATE)
+    if (result>(unsigned FACTORY_INT64)MAXIMMEDIATE)
     {
         InternalCF * res = CFFactory::basic( IntegerDomain, a, true );
         return res->mulcoeff( rhs );
     }
     #else
-    if ( ( a!=0L ) && ((result/aa!=bb) || (result>(unsigned INT64) MAXIMMEDIATE) ))
+    if ( ( a!=0L ) && ((result/aa!=bb) || (result>(unsigned FACTORY_INT64) MAXIMMEDIATE) ))
     {
         InternalCF * res = CFFactory::basic( IntegerDomain, a, true );
         return res->mulcoeff( rhs );


### PR DESCRIPTION
Fix for name INT64 causing a conflict when building Singular in cygwin64, fix for a type problem when using flint.
