### PR TITLE
fix: avoid int overflow in rlimit.c

### DIFF
--- a/Singular/rlimit.c
+++ b/Singular/rlimit.c
@@ -30,7 +30,7 @@ int raise_rlimit_nproc()
     nproc.rlim_cur = 512;
   }
   if ((nproc.rlim_max == RLIM_INFINITY || 2*nproc.rlim_cur <= nproc.rlim_max)
-      && nproc.rlim_cur < 2*nproc.rlim_cur)
+      && nproc.rlim_cur < 65536)
   {
     nproc.rlim_cur = 2*nproc.rlim_cur;
   }


### PR DESCRIPTION
(cherry picked from commit 0d44b3386987b041cec4321f5488994c04dff538)

Signed-off-by: Andreas Steenpass steenpass@mathematik.uni-kl.de
