### PR TITLE
Fix option modification by accident in primdec.lib

### DIFF
--- a/Singular/LIB/primdec.lib
+++ b/Singular/LIB/primdec.lib
@@ -786,8 +786,8 @@ static proc splitCharp(list l)
           rp=delete(rp,1);
           rp=delete(rp,1);
           keep1=keep1+rp;
-          option(noredSB);
 
+          option(noredSB);
         }
         kill RL;
       }


### PR DESCRIPTION
Hello,

this is a  proposal for eliminating accidental option modifications by 'primdec.ib'.
( http://www.singular.uni-kl.de:8002/trac/ticket/529 )

```
minAssPrimes, 
algeDeco,
splitCharp, 
minAssPrimesold,
newDecompStep 
```

needs a positive review related to changed option handling before merging.

Thanks,

Jakob
