### PR TITLE
fix documentation for 'genus()'  ( related to bug 532(trac) )

### DIFF
--- a/Singular/LIB/normal.lib
+++ b/Singular/LIB/normal.lib
@@ -2155,7 +2155,7 @@ static proc deltaP(ideal I)
 }
 
 proc genus(ideal I,list #)
-"USAGE:   genus(i) or genus(i,1); I a 1-dimensional ideal
+"USAGE:   genus(i) or genus(i,1); I a 1-dimensional ideal in a polynomial ring over the rational numbers.
 RETURN:  an integer, the geometric genus p_g = p_a - delta of the projective
          curve defined by i, where p_a is the arithmetic genus.
 NOTE:    delta is the sum of all local delta-invariants of the singularities,


### PR DESCRIPTION
genus works only over rational numbers. 
( http://www.singular.uni-kl.de:8002/trac/ticket/532 )

Documentation update proposal.
