### PR TITLE
chg: moved polymake.lib tropical.lib to LIBS1 because of dependency on o...

### DIFF
--- a/Singular/LIB/polymake.lib
+++ b/Singular/LIB/polymake.lib
@@ -1,4 +1,4 @@
-version="version oldpolymake.lib 4.0.0.0 Jun_2013 ";
+version="version polymake.lib 4.0.0.0 Jun_2013 ";
 category="Tropical Geometry";
 info="
 LIBRARY:   polymake.lib    Computations with polytopes and fans,

--- a/Singular/LIB/tropical.lib
+++ b/Singular/LIB/tropical.lib
@@ -203,7 +203,7 @@ LIB "solve.lib";
 LIB "poly.lib";
 LIB "elim.lib";
 LIB "linalg.lib";
-LIB "oldpolymake.lib";
+LIB "polymake.lib";
 LIB "primdec.lib";
 LIB "absfact.lib";
 LIB "hnoether.lib";
@@ -2718,9 +2718,9 @@ EXAMPLE:     example weightVectorToOrderMatrix;   shows an example"
         if(k<>j)  // except the unit vector of the non-zero component
         {
           intvec u;
-          u[size(w)]=0; 
+          u[size(w)]=0;
           u[k]=1;
-          O[r,1..size(w)]=u; 
+          O[r,1..size(w)]=u;
           r=r+1;
           kill u;
         }

--- a/Singular/singular-libs
+++ b/Singular/singular-libs
@@ -22,7 +22,7 @@ SLIB0 = absfact.lib ainvar.lib aksaka.lib alexpoly.lib algebra.lib \
 	noether.lib normal.lib normaliz.lib ntsolve.lib \
 	paraplanecurves.lib phindex.lib \
 	pointid.lib poly.lib \
-	polymake.lib presolve.lib primdec.lib primdecint.lib \
+	presolve.lib primdec.lib primdecint.lib \
 	primitiv.lib qhmoduli.lib random.lib realclassify.lib \
 	realrad.lib reesclos.lib resbinomial.lib \
 	resgraph.lib resjung.lib resolve.lib \
@@ -31,7 +31,7 @@ SLIB0 = absfact.lib ainvar.lib aksaka.lib alexpoly.lib algebra.lib \
 	solve.lib spcurve.lib spectrum.lib standard.lib stratify.lib \
 	surf.lib surfacesignature.lib surfex.lib \
 	teachstd.lib toric.lib triang.lib \
-	tropical.lib weierstr.lib zeroset.lib
+	weierstr.lib zeroset.lib
 
 # libs in beta testing:
 # the will be included in share.tar.gz, but not in all.lib
@@ -47,10 +47,10 @@ SLIB1 = classifyci.lib classify_aeq.lib \
         gitfan.lib \
         locnormal.lib modnormal.lib \
 	JMBTest.lib JMSConst.lib multigrading.lib\
-        orbitparam.lib parallel.lib \
+        orbitparam.lib parallel.lib polymake.lib\
 	realizationMatroids.lib resources.lib ringgb.lib \
 	schreyer.lib symodstd.lib derham.lib polybori.lib ellipticcovers.lib \
-	schubert.lib tasks.lib
+	schubert.lib tasks.lib tropical.lib
 
 PLIBS = bfun.lib central.lib dmod.lib dmodapp.lib dmodvar.lib fpadim.lib \
 	freegb.lib gkdim.lib involut.lib ncalg.lib ncdecomp.lib \


### PR DESCRIPTION
...ptional modules

this will also remove them from all.lib,
also changed some remaining, residual "oldpolamek.lib" to "polymake.lib"
