### PR TITLE
fixed typo and extended ASSUME documentation by one sentence

### DIFF
--- a/doc/general.doc
+++ b/doc/general.doc
@@ -4076,7 +4076,7 @@ and then @key{RETURN} .
 @item @strong{Purpose:}
 Tests the expression for correctness if the int_expression is smaller
 as a variable @code{assumeLevel}. If no such variable exist the int expression
-is compared against 0. It is possible to define a separate @code{assumeLevel} for each library.
+is compared against 0. It is possible to define an individual @code{assumeLevel} for each library.
 If the expression is evaluated and not true (i.e. does not evaluate to @code{int(0)} an error is raised.
 @item @strong{Example:}
 @smallexample


### PR DESCRIPTION
fixed typo and 
explicitly mentioning that it is possible to define individual assumeLevel for each library 
