### PR TITLE
fix slocus bug for zero ideal (see Singular-track 526)

### DIFF
--- a/Singular/LIB/ring.lib
+++ b/Singular/LIB/ring.lib
@@ -848,3 +848,103 @@ example
   minpoly = rootofUnity(8);
   r;
 }
+
+
+
+
+proc isQuotientRing( rng )
+"USAGE: isQuotientRing ( rng );
+RETURN:  1 if rng is a quotient ring, 0 otherwise.
+PURPOSE: check if typeof a rng "qring"
+KEYWORDS: qring ring ideal 'factor ring'
+EXAMPLE: example isQuotientRing ; shows an example
+"
+{
+    return ( size(ideal(rng)) != 0 );
+}
+example
+{
+  ring rng = 0,x,dp;
+  isQuotientRing(rng); //no
+  // if a certain method does not support quotient rings, 
+  // then a parameter test could be performed:
+   ASSUME( 0, 0==isQuotientRing(basering));
+
+  qring q= ideal(x);  // constructs rng/ideal(x) 
+  isQuotientRing(q);  // yes
+}
+
+static proc testIsQuotientRing()
+{
+   ring rng = real,x,dp;
+   ASSUME(0, 0== isQuotientRing(rng) ) ;
+
+   qring qrng = 1;
+   ASSUME(0, isQuotientRing(qrng) ) ;
+
+   ring rng2 = integer,x,dp;
+   ASSUME(0, 0 == isQuotientRing(rng2) ) ;
+
+   qring qrng2=0;
+   ASSUME(0, isQuotientRing(qrng2) ) ;
+
+   ring rng3 = 0,x,dp;
+   ASSUME(0, 0 == isQuotientRing(rng3) ) ;
+
+   qring qrng3=1;
+   ASSUME(0, isQuotientRing(qrng3) ) ;
+}
+
+
+
+
+
+proc hasIntegerCoefficientRing( rng )
+"USAGE: hasIntegerCoefficientRing ( rng );
+RETURN:  1 if rng is has integer ring coefficients, 0 otherwise.
+KEYWORDS: integer ring coefficients 
+EXAMPLE: example hasIntegerCoefficientRing ; shows an example
+"
+proc hasIntegerCoefficientRing(rng)
+{
+  def rl = ringlist(rng);
+  if ( not (typeof(rl[1][1])=="string")    ) { return (0); }
+  return ( rl[1][1]=="integer" );
+}
+example
+{
+  ring rng = integer,x,dp;
+  hasIntegerCoefficientRing(rng); //yes
+  // if a certain method supports only rings with integer coefficients, 
+  // then a parameter test could be performed:
+   ASSUME( 0, hasIntegerCoefficientRing(basering)); //ok
+
+  ring rng2 = 0, x, dp; 
+  hasIntegerCoefficientRing(rng2);  // no
+}
+
+
+static proc testHasIntegerCoefficientRing()
+{
+   ring rng = integer,x,dp;
+   ASSUME(0, hasIntegerCoefficientRing( rng ) );
+
+   qring q = ideal(x);
+   ASSUME(0, hasIntegerCoefficientRing( q ) );
+
+   ring rng2 = 0,x,dp;
+   ASSUME(0, 0==hasIntegerCoefficientRing( rng2 ) );
+
+   ring rng3 = (0,a),x,dp;
+   ASSUME(0, 0==hasIntegerCoefficientRing( rng3 ) );
+
+   ring rng4 = (real,a),x,dp;
+   ASSUME(0, 0==hasIntegerCoefficientRing( rng4 ) );
+
+   ring rng5 = (real),x,dp;
+   ASSUME(0, 0==hasIntegerCoefficientRing( rng5 ) );
+}
+
+
+
+

--- a/Singular/LIB/sing.lib
+++ b/Singular/LIB/sing.lib
@@ -361,12 +361,18 @@ example
 }
 ///////////////////////////////////////////////////////////////////////////////
 
-proc slocus (ideal i)
+proc slocus(ideal i)
 "USAGE:   slocus(i);  i ideal
-RETURN:  ideal of singular locus of i
+RETURN:  ideal of singular locus of i. Quotient rings and rings with integer coefficients are currently not supported.
 EXAMPLE: example slocus; shows an example
 "
 {
+  // quotient rings currently not supported
+  ASSUME( 0, 0==isQuotientRing(basering) ); 
+  // integer coefficient rings currently not supported
+  ASSUME( 0, 0==hasIntegerCoefficientRing(basering) ); 
+
+
   def R=basering;
   int j,k;
   ideal res;
@@ -414,9 +420,17 @@ EXAMPLE: example slocus; shows an example
 "
 {
   ideal ist=std(i);
-  if(deg(ist[1])==0){return(ist);}
-  int cod  = nvars(basering)-dim(ist);
-  i        = i+minor(jacob(i),cod);
+  if ( size(ist)==0 ) // we have a zero ideal
+  { 
+     // the zero locus of the zero ideal is nonsingular
+     return( ideal(1) ) ;
+  }
+  if( deg( ist[1] ) == 0 ) // the ideal has a constant generator
+  {
+    return(ist);
+  }
+  int cod  = nvars(basering) - dim(ist);
+  i        = i + minor( jacob(i), cod );
   return(i);
 }
 example

--- a/Tst/Short.lst
+++ b/Tst/Short.lst
@@ -50,6 +50,7 @@ Short/bug_49.tst
 Short/bug_50.tst
 Short/bug_51.tst
 Short/bug_52.tst
+Short/bug_526.tst
 Short/bug_53.tst
 Short/bug_54.tst
 Short/bug_55.tst
@@ -228,6 +229,7 @@ Short/ringmaps.tst
 Short/ringmod2m.tst
 Short/ringmodn.tst
 Short/ringsum.tst
+Short/ringutils_s.tst
 Short/ringz.tst
 Short/rInit.tst
 Short/schwarz_6_32003_lp.tst

--- a/Tst/Short/bug_526.res.gz.uu
+++ b/Tst/Short/bug_526.res.gz.uu
@@ -1,0 +1,8 @@
+begin 644 bug_526.res.gz
+M'XL("'_]SU(``V)U9U\U,C8N<F5S`%U/S0J"0!"^^Q0?T6$79'4MK9`6BCP(
+MU<4ZBZ;(@EBY2CU^:X8+,0SS\_T,DUP.\1D`%W`<Y'V5^E[`.M59R0_Q&([Q
+M'C.]8[7,9^&$+`3T,I6-[`@-K:%"B,FD*5],=9EQ6HK12<FF^K/R!:8^8&@U
+M`ZW.+5S[;1</PUP)R*+,:L@!A`'6`KLDN9XBHC4C1T7//JO).!!.84/5]UNO
+?B*308<0;<Y^[S/2<?5\<WM`J3L.Y]0'9>BN4,@$`````
+`
+end

--- a/Tst/Short/bug_526.stat
+++ b/Tst/Short/bug_526.stat
@@ -1,0 +1,4 @@
+1 >> tst_memory_0 :: 1389363540:0.9.6, 64 bit:spielwiese:x86_64-Linux:andre:271832
+1 >> tst_memory_1 :: 1389363540:0.9.6, 64 bit:spielwiese:x86_64-Linux:andr:2241992
+1 >> tst_memory_2 :: 1389363540:0.9.6, 64 bit:spielwiese:x86_64-Linux:andr:2284672
+1 >> tst_timer_1 :: 1389363540:0.9.6, 64 bit:spielwiese:x86_64-Linux:andr.de:7

--- a/Tst/Short/bug_526.tst
+++ b/Tst/Short/bug_526.tst
@@ -1,0 +1,11 @@
+// bug_526.tst
+LIB "tst.lib";
+tst_init();
+LIB "sing.lib";
+
+ring rng = 0,x,dp;
+ideal i = 0 ;
+ASSUME( 0, idealsEqual( ideal(1) , slocus(i) ) );
+
+
+tst_status(1);$

--- a/Tst/Short/ringutils_s.res.gz.uu
+++ b/Tst/Short/ringutils_s.res.gz.uu
@@ -1,0 +1,9 @@
+begin 644 ringutils_s.res.gz
+M'XL("-C_SU(``W)I;F=U=&EL<U]S+G)E<P!MD#T+PC`0AO?^BJ-3NAS$:M46
+M,JB#!1'\FJ66*(&2:G/%0?SO-D42%9?D/MZ']^YV^T6^!@`N8)7/("1#6*E3
+MF`6[=V<@H"L>E5;$HBRP/P@!C=*7EE1EC@:UO*.A@AP3"W#Q$'T\0NO"0@OW
+M-I'W23Z8,<*UJ4L@:6C;:0_6B$6N/T%XN&2*W6-5:6KUN=FT-2FI>Y)Y!\Z_
+MA<O"Y)KD13;S6I[/JOS'Q`A/EPS%[T1>./+C\\2OS+M5[/GL>5K#^`<Q$7!K
+,%67!"\IX5MN$`0``
+`
+end

--- a/Tst/Short/ringutils_s.stat
+++ b/Tst/Short/ringutils_s.stat
@@ -1,0 +1,4 @@
+1 >> tst_memory_0 :: 1389364141:0.9.6, 64 bit:spielwiese:x86_64-Linux:androm:261448
+1 >> tst_memory_1 :: 1389364141:0.9.6, 64 bit:spielwiese:x86_64-Linux:androm:2240296
+1 >> tst_memory_2 :: 1389364141:0.9.6, 64 bit:spielwiese:x86_64-Linux:androm:2281280
+1 >> tst_timer_1 :: 1389364141:0.9.6, 64 bit:spielwiese:x86_64-Linux:androm:7

--- a/Tst/Short/ringutils_s.tst
+++ b/Tst/Short/ringutils_s.tst
@@ -1,0 +1,17 @@
+LIB "tst.lib";
+tst_init();
+
+
+LIB("ring.lib");
+
+proc testRingUtils()
+{
+  Ring::testIsQuotientRing();
+  Ring::testHasIntegerCoefficientRing();
+}
+testRingUtils();
+
+
+tst_status(1);
+quit;
+


### PR DESCRIPTION
fix 'slocus' bug for zero ideal (see Singular-track 526, http://www.singular.uni-kl.de:8002/trac/ticket/526)

In addition ASSUME statements were added which check 
if a current ring is supported by 'slocus'. 
(qrings rings and rings with integer coefficients are not supported)
