### PR TITLE
Alternate fix for building with FLINT but w/o NTL

### DIFF
--- a/factory/facFqSquarefree.cc
+++ b/factory/facFqSquarefree.cc
@@ -238,11 +238,11 @@ squarefreeFactorization (const CanonicalForm & F, const Variable & alpha)
     return CFFList (CFFactor (F/Lc(F), 1));
 
   CanonicalForm buffer;
-#ifdef HAVE_NTL
+#if defined(HAVE_NTL) || (HAVE_FLINT && __FLINT_VERSION_MINOR >= 4)
   if (alpha.level() == 1)
 #endif
     buffer= pthRoot (A, ipower (p, k));
-#if (HAVE_NTL && HAVE_FLINT && __FLINT_VERSION_MINOR >= 4)
+#if (HAVE_FLINT && __FLINT_VERSION_MINOR >= 4)
   else
   {
     fmpz_t qq;


### PR DESCRIPTION
In commit f1cab7c9992f5d, a change was made to fix building without NTL but with FLINT. That fix looks strange to me; the commit here does what _seems_ right. But then I am not so familiar with the code, so I wouldn't be surprised if I am misunderstanding something :-).
