### PR TITLE
fix for bug 527 and correct return data structure in case zero ideal is passed to primdecZ

### DIFF
--- a/Singular/LIB/primdecint.lib
+++ b/Singular/LIB/primdecint.lib
@@ -41,7 +41,7 @@ RETURN:  a list pr of primary ideals and their associated primes:
 EXAMPLE: example primdecZ; shows an example
 "
 {
-   if(size(I)==0){return(list(ideal(0),ideal(0)));}
+   if(size(I)==0){return(list(list(ideal(0),ideal(0))));}
 
 //--------------------  Initialize optional parameters  ------------------------
    if(size(#) > 0)
@@ -96,6 +96,7 @@ EXAMPLE: example primdecZ; shows an example
       list L = primefactors(q);
 
       list A;
+      A[1]= ideal(0);
       ideal J = imap(R,J);
 
       for(j=1;j<=size(L[2]);j++)
@@ -183,7 +184,7 @@ EXAMPLE: example primdecZ; shows an example
       {
          "A is computed in "+string(rtimer - RT)+" seconds.";
       }
-      for(i=1;i<=size(A);i++)
+      for(i=2;i<=size(A);i++)
       {
       //=== computes for all p in L the minimal associated primes of
       //=== IZ/p[variables]
@@ -943,21 +944,21 @@ static proc modp(ideal J, int p, int nu)
    def Rp = ring(rp);
    setring Rp;
    ideal J = imap(R,J);
+   int sizeA;
    if(nu > 1)
    {
       //=== p is of multiplicity > 1 in q
-      list A = minAssGTZ(J);
-      setring R;
-      list A = imap(Rp,A);
-      return(list(A,p,nu));
+      list A = minAssGTZ(J);   
    }
    else
    {
       list A = primdecGTZ(J);
-      setring R;
-      list A = imap(Rp,A);
-      return(list(A,p,nu));
    }
+   sizeA = size(A);     
+   setring R;
+   list A;
+   if (sizeA>0)   {  A = imap(Rp,A);    }
+   return(list(A,p,nu));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1099,10 +1100,11 @@ static proc extractZ(ideal J, int j, list L, list B)
          if(L[1][3]==nvars(basering))
          {
             list C;
+            C[1]= ideal(0); //add dummy entry to tie C to current ring
             int i;
             for(i=1;i<=size(I);i++)
             {
-               C[i]=I[i];
+               C[i+1]=I[i];
             }
          }
          else
@@ -1113,10 +1115,11 @@ static proc extractZ(ideal J, int j, list L, list B)
             execute(quotring);
             ideal I=imap(Shelp,I);
             list C;
+            C[1]= ideal(0); //add dummy entry to tie C to current ring
             int i;
             for(i=1;i<=size(I);i++)
             {
-               C[i]=leadcoef(I[i]);
+               C[i+1]=leadcoef(I[i]);
             }
             setring Shelp;
             list C=imap(quring,C);
@@ -1128,17 +1131,18 @@ static proc extractZ(ideal J, int j, list L, list B)
       {
          I=stdZ(I);
          list C;
+         C[1]= ideal(0); //add dummy entry to tie C to current ring
          int i;
          for(i=1;i<=size(I);i++)
          {
-            C[i]=I[i];
+            C[i+1]=I[i];
          }
          list rl=ringlist(R);
          rl[1]=0;
          def Shelp =ring(rl);
       }
       poly h=1;
-      for(i=1;i<=size(C);i++)
+      for(i=2;i<=size(C);i++) // leave out first dummy entry in C.
       {
          if(deg(C[i])>0){h=h*C[i];}  // das muss noch besser gemacht werden,
                                      // nicht ausmultiplizieren!

--- a/Tst/Short.lst
+++ b/Tst/Short.lst
@@ -51,6 +51,7 @@ Short/bug_50.tst
 Short/bug_51.tst
 Short/bug_52.tst
 Short/bug_526.tst
+Short/bug_527_s.tst
 Short/bug_53.tst
 Short/bug_54.tst
 Short/bug_55.tst

--- a/Tst/Short/bug_527_s.res.gz.uu
+++ b/Tst/Short/bug_527_s.res.gz.uu
@@ -1,0 +1,10 @@
+begin 644 bug_527_s.res.gz
+M'XL("+I(`E,``V)U9U\U,C=?<RYR97,`=9)1:X,P%(7?_14'V4,<$DRLU5(2
+MV-@>A&TO=B\;0]J92:`34<NZ_?I%6XQ0^Q!RR?WN.;F7FVT>TA<`3.(IO8?;
+MM1W=ZYV[=K)SADN8QUQ7NB/>VNEO2(G=H<PC'N<MK=0/;;MM-U:$$F.\H+TN
+M<>M&?Q?J4U<G><_J1Q-Z2='HJD1CCH"!5:D:GQS]7\\O:EL32^A";?=(#<;L
+M>R)1J"_4QLDDSIYO))W8K23NLNSU^9$$/EK]ITA/>T($%F*!_1-C%*D(;,[,
+M8T;?\N&%P8GW(`0#INAB'GUG'P,-;BYK'%VEAP+3`28M+*_3_)*.)PTGU,8K
+H.HPXN3V.+`]F!S"FF97BW$KQD`Y[U&_*H27,S.'&^0<^:NL_?@(`````
+`
+end

--- a/Tst/Short/bug_527_s.stat
+++ b/Tst/Short/bug_527_s.stat
@@ -1,0 +1,4 @@
+1 >> tst_memory_0 :: 1392659922:4.0.0, 64 bit:4.0.0:x86_64-Linux:androm:303176
+1 >> tst_memory_1 :: 1392659922:4.0.0, 64 bit:4.0.0:x86_64-Linux:androm:2363392
+1 >> tst_memory_2 :: 1392659922:4.0.0, 64 bit:4.0.0:x86_64-Linux:androm:2445312
+1 >> tst_timer_1 :: 1392659922:4.0.0, 64 bit:4.0.0:x86_64-Linux:androm:9

--- a/Tst/Short/bug_527_s.tst
+++ b/Tst/Short/bug_527_s.tst
@@ -1,0 +1,24 @@
+LIB "tst.lib";
+tst_init();
+
+LIB("primdecint.lib");
+
+ring rng = integer,(x,y),dp;
+ideal I = 1;
+def pdec = primdecZ(I);
+ASSUME(0, size(pdec)==0);
+
+I=0;
+pdec = primdecZ(I); 
+ASSUME(0, size( pdec ) ==1  ); 
+ASSUME(0, size( pdec[1] ) == 2 ) ;
+ASSUME(0, size( pdec[1][1] )==0 );
+ASSUME(0, size( pdec[1][2] )==0 );
+
+
+I = 8*x;
+pdec = primdecZ(I);
+
+
+tst_status(1); $
+


### PR DESCRIPTION
fixes also the following sort of bugs:
1. 
in the past `primdecZ(ideal(0))`
returned 

```
list(ideal(0),ideal(0))
[1]
   _[1]=0
[2]
   _[1]=0

```

but correct is:

```
list(list(ideal(0),ideal(0)))
[1]
   [1]
      _[1]=0
   [2]
      _[1]=0

```

2.

```
ring rng = integer, (xk,xx),dp;
ideal I = 8*xk;
primdecZ(I);
  ? identifier C not found in Shelp
   ? error occurred in or before primdecint.lib::extractZ line 1123: `         list C=imap(Shelp,C);`
   ? leaving primdecint.lib::extractZ
```
