### PR TITLE
ignored assignment may shadow bugs. turned into error

### DIFF
--- a/Singular/ipassign.cc
+++ b/Singular/ipassign.cc
@@ -847,7 +847,7 @@ static BOOLEAN jiAssign_1(leftv l, leftv r)
   }
   if(rt==NONE)
   {
-    WarnS("right side is not a datum, assignment ignored");
+    Werror("assignment: right side is not a datum or index out of bounds!");
     // if (!errorreported)
     //   WerrorS("right side is not a datum");
     //return TRUE;


### PR DESCRIPTION
In fact, the warning already did shadow a bug, see 
http://www.singular.uni-kl.de:8002/trac/ticket/532
and now it shadowed a bug in Primdec::testPrimary.

Therefore I vote to turn this warning into an error.
