### PR TITLE
fix: do not change sign of residual form in realclassify.lib

### DIFF
--- a/Singular/LIB/realclassify.lib
+++ b/Singular/LIB/realclassify.lib
@@ -605,7 +605,16 @@ EXAMPLE:  example morsesplit; shows an example"
     f = jet(f, k);
     h = f-jet(f, 2)-corank_part(f);
   }
-  poly g = cleardenom(f-jet(f, 2));
+  poly g = f-jet(f, 2);
+  poly lead_g = leadcoef(g);
+  if(lead_g > 0)
+  {
+    g = g/lead_g;
+  }
+  if(lead_g < 0)
+  {
+    g = -g/lead_g;
+  }
 
   return(list(c, lambda, k, g));
 }


### PR DESCRIPTION
(cherry picked from commit 3ac9114362c0eb5bc8d012d4a95b6bc92a7bc2ac)

Signed-off-by: Andreas Steenpass steenpass@mathematik.uni-kl.de
