### PR TITLE
add quotient ring check in 'normal.lib' functions

### DIFF
--- a/Singular/LIB/normal.lib
+++ b/Singular/LIB/normal.lib
@@ -144,6 +144,8 @@ SEE ALSO: normalC, normalP.
 EXAMPLE: example normal; shows an example
 "
 {
+  ASSUME(0, not isQuotientRing(basering) );
+
   intvec opt = option(get);     // Save current options
 
   int i,j;
@@ -601,6 +603,8 @@ NOTE:    printlevel >=1: display comments (default: printlevel=0)
 EXAMPLE: example HomJJ;  shows an example
 "
 {
+   ASSUME(0, not isQuotientRing(basering) );
+
 //---------- initialisation ---------------------------------------------------
    int isIso,isPr,isHy,isCo,isRe,isEq,oSAZ,ii,jj,q,y;
    intvec rw,rw1;
@@ -960,7 +964,10 @@ THEORY:  If r=size(L)=2 then iMult(L) = vdim(std(L[1]+L[2])) and in general
          delta(I) = vdim (normalisation(R/I)/(R/I)), R the basering.
 EXAMPLE: example iMult; shows an example
 "
-{    int i,mul,mu;
+{    
+     ASSUME(0, not isQuotientRing(basering) );
+
+     int i,mul,mu;
      int sp = size(prim);
      int y = printlevel-voice+2;
      if ( sp > 1 )
@@ -1011,6 +1018,8 @@ NOTE:    only useful in affine rings, in local rings vdim does the check
 EXAMPLE: example locAtZero; shows an example
 "
 {
+   ASSUME(0, not isQuotientRing(basering) );
+
    int ii,jj, caz;                   //caz: conzentrated at zero
    int dbp = printlevel-voice+2;
    int nva = nvars(basering);
@@ -1106,6 +1115,7 @@ RETURN:   a list of rings, say nor, and an integer, the delta-invariant
 EXAMPLE: example normalizationPrimes; shows an example
 "
 {
+   ASSUME(1, not isQuotientRing(basering) );
    //Note: this procedure calls itself as long as the test for
    //normality, i.e if R==Hom(J,J), is negative.
 
@@ -2014,6 +2024,8 @@ static proc substpart(ideal endid, ideal endphi, int homo, intvec rw)
 //fj and hence the order does'nt matter when substitutinp xi by fi
 
 {
+   ASSUME(1, not isQuotientRing(basering) );
+
    def newRing = basering;
    int ii,jj;
    map phi = newRing,maxideal(1);    //identity map
@@ -2120,6 +2132,7 @@ Versuch: subst statt phi
 ///////////////////////////////////////////////////////////////////////////////
 static proc deltaP(ideal I)
 {
+   ASSUME(1, not isQuotientRing(basering) );
    def R=basering;
    int c,d,i;
    int n=nvars(R);
@@ -2169,6 +2182,8 @@ NOTE:    genus always treats projective curves and takes projective closure if i
 EXAMPLE: example genus; shows an example
 "
 {
+   ASSUME(0, not isQuotientRing(basering) );
+
    int w = printlevel-voice+2;  // w=printlevel (default: w=0)
 
    int ono,rpr,ll;
@@ -2622,6 +2637,8 @@ KEYWORDS: delta invariant; Tjurina number
 EXAMPLE: example deltaLoc;  shows an example
 "
 {
+   ASSUME(0, not isQuotientRing(basering) );
+
    intvec save_opt=option(get);
    option(redSB);
    def R=basering;
@@ -3207,7 +3224,11 @@ EXAMPLE:  example closureFrac; shows an example
   int i,j,k,l,n2,n3;
   intvec V;
   string mapstr;
-  for (i=1; i<=n; i++) { def R(i) = L[i]; }
+  for (i=1; i<=n; i++) 
+  {
+    ASSUME(0, not isQuotientRing( L[i] ) );
+    def R(i) = L[i]; 
+  }
 
 // The quotient representing f is computed as in 'closureGenerators' with
 // the differences that
@@ -3384,7 +3405,8 @@ proc closureGenerators(list L);
 
   for (int i=1; i<=n; i++)
   {
-     def R(i)=L[i];          //give the rings from L a name
+     ASSUME(0, not isQuotientRing(L[i]) );
+     def R(i) = L[i];          //give the rings from L a name
   }
 
   // For each variable (counter j) and for each intermediate ring (counter k):
@@ -3394,6 +3416,7 @@ proc closureGenerators(list L);
   for (j=1; j <= length+1; j++ )
   {
       setring R(n);
+
       if (j==1)
       {
         poly p;
@@ -3568,6 +3591,8 @@ SEE ALSO: normal, normalC
 EXAMPLE: example normalP; shows an example
 "
 {
+   ASSUME(0, not isQuotientRing(basering) );
+
    int i,j,y, sr, del, co;
    intvec deli;
    list resu, Resu, prim, Gens, mstdid;
@@ -3801,6 +3826,8 @@ example
 
 static proc normalityTest(list mstdid)
 {
+   ASSUME(1, not isQuotientRing(basering) );
+
    int y = printlevel-voice+2;
    intvec op = option(get);
    option(redSB);
@@ -3899,6 +3926,8 @@ static proc normalityTest(list mstdid)
 
 static proc substpartSpecial(ideal endid, ideal endphi)
 {
+   ASSUME(1, not isQuotientRing(basering) );
+
    //Note: newRing is of the form (R the original basering):
    //char(R),(T(1..N),X(1..nvars(R))),(dp(N),...);
 
@@ -4057,6 +4086,8 @@ static proc substpartSpecial(ideal endid, ideal endphi)
 // attempted.
 static proc computeRing(ideal J, ideal I, list #)
 {
+  ASSUME(1, not isQuotientRing(basering) );
+
   int i, ii,jj;
   intvec V;                          // to be used for variable weights
   int y = printlevel-voice+2;
@@ -4313,6 +4344,8 @@ static proc normalM(ideal I, int decomp, int withDelta, int denomOption, ideal i
 
 // denomOption = 0      -> Uses the smallest degree polynomial
 // denomOption = i > 0  -> Uses a polynomial in the i-th variable
+
+  ASSUME(1, not isQuotientRing(basering) );
 
   intvec save_opt=option(get);
   option(redSB);
@@ -4612,6 +4645,7 @@ static proc normalMEqui(ideal I, ideal origJ, poly condu, poly D, int withDelta)
 // condu is a non-zerodivisor in the conductor or 0 if it was not computed.
 // If withDelta = 1, computes the delta invariant.
 {
+  ASSUME(1, not isQuotientRing(basering) );
   int step = 0;                       // Number of steps. (for debugging)
   int dbg = printlevel - voice + 2;   // dbg = printlevel (default: dbg = 0)
   int i;                              // counter
@@ -4838,6 +4872,10 @@ NOTE:    Works only over rings of two variables.@*
 EXAMPLE: example getOneVar; shows an example
 "
 {
+  ASSUME(0, not isQuotientRing(basering) );
+  ASSUME(0, nvars(basering)==2 );
+  ASSUME(0, (vari==2) || (vari==1) );
+
   def R = basering;
   list RL = ringlist(R);
   // We keep everything from R but we change the ordering to lp, and we
@@ -4878,6 +4916,7 @@ NOTE:    It looks only at the generator of J, not at all the polynomials in
 EXAMPLE: example getSmallest; shows an example
 "
 {
+
 // Computes the polynomial of smallest degree of J.
 //
   int i;
@@ -4924,6 +4963,7 @@ example
 
 static proc getGenerators(ideal J, ideal U, poly c)
 {
+
 // Computes the generators of J as an ideal in the original ring,
 // where J is given by generators in the new ring.
 
@@ -4961,6 +5001,9 @@ static proc getGenerators(ideal J, ideal U, poly c)
 
 static proc testIdeal(ideal I, ideal U, ideal origJ, poly c, poly D)
 {
+
+  ASSUME(1, not isQuotientRing(basering) );
+
 // Internal procedure, used in normalM.
 // Computes the test ideal in the new ring.
 // It takes the original test ideal and computes the radical of it in the
@@ -5134,6 +5177,7 @@ NOTE:    It assumes that such U2 exists. It is intended maninly as an auxiliary
 EXAMPLE: example changeDenominator; shows an example
 "
 {
+  ASSUME(0, not isQuotientRing(basering) );
 // Let A = R / I. Given an A-module in the form 1/c1 * U1 (U1 ideal of A), it
 // computes a new ideal U2 such that the the A-module is 1/c2 * U2.
 // The base ring is R, but the computations are to be done in R / I.
@@ -5235,6 +5279,7 @@ static proc checkInclusions(ideal U1, ideal U2)
 
 static proc degSubring(poly p, intvec @v)
 {
+  ASSUME(1, not isQuotientRing(basering) );
 // Computes the degree of a polynomial taking only some variables as variables
 // and the others as parameters.
 
@@ -5254,6 +5299,8 @@ static proc degSubring(poly p, intvec @v)
 
 static proc mapBackIdeal(ideal I, poly c, intvec @v)
 {
+   ASSUME(1, not isQuotientRing(basering) );
+
 // Modifies all polynomials in I so that a map x(i) -> y(i)/c can be
 // carried out.
 
@@ -5271,6 +5318,8 @@ static proc mapBackIdeal(ideal I, poly c, intvec @v)
 
 static proc mapBackPoly(poly p, poly c, intvec @v)
 {
+  ASSUME(1, not isQuotientRing(basering) );
+
 // Multiplies each monomial of p by a power of c so that a map x(i) -> y(i)/c
 // can be carried out.
 
@@ -5612,6 +5661,8 @@ SEE ALSO: normal, normalP.
 EXAMPLE: example normalC; shows an example
 "
 {
+   ASSUME(0, not isQuotientRing(basering) );
+
    int i,j;
    int withGens, withEqui, withPrim, isPrim, noFac;
    int dbg = printlevel-voice+2;
@@ -6282,6 +6333,8 @@ example
 
 proc timeNormal(ideal I, list #)
 {
+  ASSUME(0, not isQuotientRing(basering) );
+
   def r = basering;
 
   //--------------------------- define the method ---------------------------
@@ -6518,6 +6571,7 @@ NOTE:    For big examples it can be hard to fully test correctness; the
 EXAMPLE: example norTest; shows an example
 "
 {
+   ASSUME(0, not isQuotientRing(basering) );
 //### Sollte erweitert werden auf den reduziblen Fall: einen neuen affinen
 // Ring nor[1][1]+...+nor[1][r] (direkte Summe) erzeugen, map dorthin
 // definieren und dann testen.


### PR DESCRIPTION
depends on 
https://github.com/Singular/Sources/pull/574 (merge first!)
otherwise tests will fail.

Attention: The `not isQuotientRing` in `getOneVar()` will break some tests/examples,
 butconsider that getOneVar() comments clearly state that it will fail in quotient ring.

Failing Tests:

paraPlaneCurve
paraConic
adjointIdeal
mapToRatNormCurve
testParametrization
rncAntiCanonicalMap
rncItProjEven
invertBirMap
