### PR TITLE
fix unintentional basering change in algebra::is_injective()

### DIFF
--- a/Singular/LIB/algebra.lib
+++ b/Singular/LIB/algebra.lib
@@ -586,6 +586,7 @@ EXAMPLE: example is_injective; shows an example
       map psi = S,proj;
       L[1] = size(NF(psi(ker),std(0))) == 0;
     }
+    setring bsr;
     if ( defined(pau) != voice )
     {  return (L[1]);
     }

--- a/Tst/Short.lst
+++ b/Tst/Short.lst
@@ -64,6 +64,7 @@ Short/bug_5.tst
 Short/bug_6.tst
 Short/bug_609.tst
 Short/bug_613.tst
+Short/bug_633.tst
 Short/bug_7.tst
 Short/bug_8.tst
 Short/bug_9.tst

--- a/Tst/Short/bug_633.res.gz.uu
+++ b/Tst/Short/bug_633.res.gz.uu
@@ -1,0 +1,10 @@
+begin 644 bug_633.res.gz
+M'XL("#\PWE,``V)U9U\V,S,N<F5S`$V0L6Z#,!"&=Y[BA#J8].*$T*2M4#U4
+M79"J+LD>3'"H*PK(-I#DZ7ND$63RK_L_^73?=O>1?`%`*.`S>0??6<=+G?FQ
+MM[TU*P$TW.M*.Q;$WO""$)"UQ7X31;Q2/;=.NI&/!(SYB4/=.%U7K)>F"J9/
+MUW?0A@^KF2_+0F5&7M??H<\"=.6@@3=H#*52=:J<ZA<!-"W`4+]$)C'#0X"Y
+MG8C7&V'_B1.>\8(M=M@3UXQ<N*1%N9(E)`2>YCVVJ_XQQ/-EWDT0>?J5#33?
+MFB"#R=20)VU)TX\Z.-TI1@@:NB,<B3LS(9D9\YI?#0\66\O"((8';[&`V0Q:
+:JR"EFU-28)V2.=1'2'-U3+T_(5>H_;D!````
+`
+end

--- a/Tst/Short/bug_633.stat
+++ b/Tst/Short/bug_633.stat
@@ -1,0 +1,4 @@
+1 >> tst_memory_0 :: 1407070271:4.0.0, 64 bit:4.0.0:x86_64-Linux:androm:256408
+1 >> tst_memory_1 :: 1407070271:4.0.0, 64 bit:4.0.0:x86_64-Linux:androme:2245056
+1 >> tst_memory_2 :: 1407070271:4.0.0, 64 bit:4.0.0:x86_64-Linux:androm:2290792
+1 >> tst_timer_1 :: 1407070271:4.0.0, 64 bit:4.0.0:x86_64-Linux:androm:4

--- a/Tst/Short/bug_633.tst
+++ b/Tst/Short/bug_633.tst
@@ -1,0 +1,16 @@
+LIB "tst.lib";
+tst_init();
+
+option(warn);
+
+LIB("algebra.lib");
+int p = printlevel;
+ring r = 0,(a,b,c),ds;
+ring s = 0,(x,y,z,u,v,w),dp;
+ideal I = x-w,u2w+1,yz-v;
+map phi = r,I;
+is_injective(phi,r);
+
+
+tst_status(1); $
+


### PR DESCRIPTION
following warning 

```
// ** option changed in proc is_injective from algebra.lib
-redTail -redThrough
```

will disappear 
for 

```
option(warn);

LIB("algebra.lib");
int p = printlevel;
ring r = 0,(a,b,c),ds;
ring s = 0,(x,y,z,u,v,w),dp;
ideal I = x-w,u2w+1,yz-v;
map phi = r,I;
is_injective(phi,r);

```
