### PR TITLE
bugfix for ticket 574

### DIFF
--- a/Singular/LIB/primdecint.lib
+++ b/Singular/LIB/primdecint.lib
@@ -66,7 +66,7 @@ EXAMPLE: example primdecZ; shows an example
    }
 
 
-   if(deg(I[1]) == 0)
+   if(size(I)==1 && deg(I[1]) == 0)
    {
       ideal J = I;
    }
@@ -94,7 +94,6 @@ EXAMPLE: example primdecZ; shows an example
       setring Rhelp;
       number q=imap(R,q);
       //=== computes the primes occuring in a generator of I intersect Z
-
       list L = primefactors(q);
 
       list A;
@@ -170,13 +169,14 @@ EXAMPLE: example primdecZ; shows an example
             }
             i_sleep = system("sh", "sleep "+string(t));
          }
-
       }
       else
       {
          for(j=1;j<=size(L[2]);j++)
          {
-            A[size(A)+1] = modp(J, L[1][j], L[2][j]);
+            p=int(L[1][j]);
+            nu=int(L[2][j]);
+            A[size(A)+1] = modp(J, p,nu );
          }
       }
 

--- a/Tst/Short.lst
+++ b/Tst/Short.lst
@@ -54,6 +54,7 @@ Short/bug_52.tst
 Short/bug_526.tst
 Short/bug_527_s.tst
 Short/bug_529.tst
+Short/bug_574.tst
 Short/bug_597.tst
 Short/bug_53.tst
 Short/bug_54.tst

--- a/Tst/Short/bug_574.res.gz.uu
+++ b/Tst/Short/bug_574.res.gz.uu
@@ -1,0 +1,10 @@
+begin 644 bug_574.res.gz
+M'XL("+.^WU,``V)U9U\U-S0N<F5S`$U138^",!"]\RM>R!Y`V+KE0R5$3#9[
+M(5F\N*<]:!0J-B"04B(_?\MJ@$,STS?OO9EI#S]?\1X`C?`=?T*7K20EO^BA
+M=GA5G`@*//&*2\,,M2$BBG#I\I._]DC%'J259SGRW0AC[I'!U=`;P>\92WGU
+M-#<G=S^"X%4.H<X6BL!R)FRC+^R>F7;63,S5S'=-P#-V+A$K4;#HBZ-K;52P
+M?'OD;`@<!2UZ=G3>AZ(*E*KK1`D(!EAA5C`VHA]3(TH),G9%DB3;>YUU)3/B
+M:7CJS)CND]FH-=5,KX5_$T-)S7"YQ*U^0-9(;RPM<*T%TEH(ELJ*M2WJIW"W
+?&^V\F;5/IGQ%_G]C>/&N-:@9XBW4_@!4B\"=Q0$`````
+`
+end

--- a/Tst/Short/bug_574.stat
+++ b/Tst/Short/bug_574.stat
@@ -1,0 +1,4 @@
+1 >> tst_memory_0 :: 1407172275:4.0.0, 64 bit:4.0.0:x86_64-Linux:andromed:388568
+1 >> tst_memory_1 :: 1407172275:4.0.0, 64 bit:4.0.0:x86_64-Linux:andromed:2437120
+1 >> tst_memory_2 :: 1407172275:4.0.0, 64 bit:4.0.0:x86_64-Linux:andromed:2555904
+1 >> tst_timer_1 :: 1407172275:4.0.0, 64 bit:4.0.0:x86_64-Linux:andromed:9

--- a/Tst/Short/bug_574.tst
+++ b/Tst/Short/bug_574.tst
@@ -1,0 +1,17 @@
+LIB "tst.lib";
+tst_init();
+
+LIB("primdecint.lib");
+ring rng = integer,(xk,xe),dp;
+
+ideal I = 9*xk^3+8*xk+5,
+2*xk*xe^2-8*xk^2-11*xe,
+xk^2*xe+9;
+
+def MMM=module(I);
+
+def pdec = primdecZM(MMM);// how to check for correctness of pdec??
+
+
+tst_status(1); $;
+


### PR DESCRIPTION
- the unfortunate check at line 69 caused coefficient swallow, fixed now.
- At line 179 `modp` was called incorrectly

open: how to check result correctness?
