### PR TITLE
fix: stupid erroneous break

### DIFF
--- a/factory/facAlgFunc.cc
+++ b/factory/facAlgFunc.cc
@@ -524,7 +524,6 @@ Trager (const CanonicalForm & F, const CFList & Astar,
         f /= vcontent (f, as.getFirst().mvar());
 
         L.append (CFFactor (f, 1));
-        break;
       }
       else
       {


### PR DESCRIPTION
fix for:

def assumeLevel = 3;
LIB("ehv.lib");

ring rng = (7,vv),(xz,xt,xc,xi),(dp(4),C);
minpoly = (vv^2+vv+3);
ideal I =
(3_vv-2)_xz_xi+(vv-3),(3_vv-2)_xc^3+3_xc-3,xz_xt^2+3_xt_xi+(3_vv)*xt-xi;

list L1 = primdecGTZ(I);
list L2 = primdecSY(I);
L1 = removeRedundantComponents(L1);
L1;
L2;

see Kroeker email

which fails only if build without FLINT
