### PR TITLE
Move FLINTrandom into factory to fix test suite crashes

### DIFF
--- a/Singular/misc_ip.cc
+++ b/Singular/misc_ip.cc
@@ -1327,13 +1327,6 @@ static BOOLEAN iiCrossProd(leftv res, leftv args)
 /*2
 * initialize components of Singular
 */
-#ifdef HAVE_FLINT
-extern "C" 
-{
-GLOBAL_VAR flint_rand_t FLINTrandom;
-}
-#endif
-
 void siInit(char *name)
 {
 // memory initialization: -----------------------------------------------
@@ -1396,9 +1389,6 @@ void siInit(char *name)
   factoryseed(t);
   siRandomStart=t;
   feOptSpec[FE_OPT_RANDOM].value = (void*) ((long)siRandomStart);
-  #ifdef HAVE_FLINT
-  flint_randinit(FLINTrandom);
-  #endif
 
 // ressource table: ----------------------------------------------------
   // Don't worry: ifdef OM_NDEBUG, then all these calls are undef'ed

--- a/factory/cf_random.cc
+++ b/factory/cf_random.cc
@@ -14,6 +14,18 @@
 #include "gfops.h"
 #include "imm.h"
 
+#ifdef HAVE_FLINT
+extern "C"
+{
+#ifndef __GMP_BITS_PER_MP_LIMB
+#define __GMP_BITS_PER_MP_LIMB GMP_LIMB_BITS
+#endif
+#include <flint/flint.h>
+
+GLOBAL_VAR flint_rand_t FLINTrandom;
+}
+#endif
+
 class RandomGenerator {
 private:
     const int ia, im, iq, ir, deflt;
@@ -173,7 +185,12 @@ int factoryrandom( int n )
         return ranGen.generate() % n;
 }
 
+
 void factoryseed ( int s )
 {
     ranGen.seed( s );
+
+#ifdef HAVE_FLINT
+    flint_randinit(FLINTrandom);
+#endif
 }


### PR DESCRIPTION
Without this, `make check` runs into segfaults in tests that use factory but
not the full Singular library, as factory accesses FLINTrandom but does not
contain its definition.