### PR TITLE
Add basic GitHub Actions CI tests

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -1,0 +1,42 @@
+name: Run tests
+
+# Trigger the workflow on push or pull request
+on: [push, pull_request]
+
+env:
+  prefix: "/tmp/prefix"
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        configflags: ["", "--without-ntl --with-flint"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Install dependencies"
+        run: |
+               if [ "$RUNNER_OS" == "Linux" ]; then
+                    # sharutils is for uudecode
+                    sudo apt install sharutils libgmp-dev libreadline-dev libmpfr-dev libntl-dev libcdd-dev 4ti2 normaliz
+                    # install new enough FLINT (>= 2.6.0)
+                    wget -O FLINT.tar.gz "https://github.com/JuliaBinaryWrappers/FLINT_jll.jl/releases/download/FLINT-v2.6.0%2B0/FLINT.v2.6.0.x86_64-linux-gnu.tar.gz"
+                    sudo tar -C /usr -xvf FLINT.tar.gz
+                    rm -f FLINT.tar.gz
+               elif [ "$RUNNER_OS" == "macOS" ]; then
+                    brew install autoconf automake libtool gmp readline mpfr ntl flint cddlib
+                    # TODO: 4ti2?
+                    # TODO: normaliz?
+               else
+                    echo "$RUNNER_OS not supported"
+                    exit 1
+               fi
+      - run: ./autogen.sh
+      - run: ./configure --prefix=$prefix --enable-gfanlib ${{ matrix.configflags }}
+      - run: make -j3
+      - run: make check
+      - run: make install
+
+# TODO: code coverage?

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,5 @@
 #! /bin/sh
+set -e
 
 cd `dirname "$0"`
 


### PR DESCRIPTION
This adds basic CI tests to this repository using GitHub Actions. For now, all these do is to build Singular and then run `make check`, with a build matrix consisting of four jobs: 
- using Ubuntu or macOS
- using a default configure invocation, or else one with `--without-ntl --with-flint`

Note that on macOS, Flint 2.6.0 is installed, while on Ubuntu Flint 2.5.2. As a result, one of the four builds (the one using `--with-flint` on the Ubuntu machine with Flint 2.5.2) fails (due to a segfault in factory's `make check). I left it in as commit 249d818e57a3c49f4e561e2a5fe38db7dbc9f2c0 indicates that Flint 2.5.2 ought to be supported. I guess we should either fix `make check` there or else change configure to require Flint 2.6?