### PR TITLE
Tst/regress.cmd: avoid multiples of 256 as exit code

### DIFF
--- a/Tst/regress.cmd
+++ b/Tst/regress.cmd
@@ -1208,6 +1208,10 @@ if( length($teamcity) > 0 )
 
 
 # Und Tschuess
+if ($exit_code != 0 && ($exit_code % 256) == 0)
+{
+  $exit_code = 1;
+}
 exit $exit_code;
 
 


### PR DESCRIPTION
Running this script gave me a test failure, yet the exit code was 0. Digging
closer, it turns out the perl script tried to use exit code 256 for some
reason I don't understand. But exit codes are a single byte, so any multiple
of 256 gets mapped to 0, giving the false impression that the test suite
passes when it actually is failing.