### PR TITLE
Fix broken GMP_HOME check

### DIFF
--- a/factory/configure.ac
+++ b/factory/configure.ac
@@ -225,8 +225,10 @@ BACKUP_LIBS=${LIBS}
 for GMP_HOME in ${GMP_HOME_PATH}
 do
   if test "x$GMP_HOME" != "x/usr"; then
-    GMP_CPPFLAGS="-I${GMP_HOME}/include"
-    GMP_LIBS="-L${GMP_HOME}/lib -Wl,-rpath -Wl,${GMP_HOME}/lib -lgmp"
+    if test -e ${GMP_HOME}/include/gmp.h; then
+      GMP_CPPFLAGS="-I${GMP_HOME}/include"
+      GMP_LIBS="-L${GMP_HOME}/lib -Wl,-rpath -Wl,${GMP_HOME}/lib -lgmp"
+    fi
   else
     GMP_CPPFLAGS=""
     GMP_LIBS="-lgmp"


### PR DESCRIPTION
Add a missing test for gmp.h, otherwise GMP_HOME gets unconditionally set to /opt/local, producing a broken RPATH in the compiled library and in the pc file

Fixes https://www.singular.uni-kl.de:8002/trac/ticket/870