### PR TITLE
Change ZnmInfo member exp to unsigned long

### DIFF
--- a/libpolys/coeffs/rmodulon.h
+++ b/libpolys/coeffs/rmodulon.h
@@ -15,7 +15,7 @@ struct snumber; typedef struct snumber *   number;
 #ifdef HAVE_RINGS
 #include "coeffs/rintegers.h"
 
-typedef struct { mpz_ptr base;  int exp; } ZnmInfo;
+typedef struct { mpz_ptr base;  unsigned long exp; } ZnmInfo;
 
 BOOLEAN nrnInitChar    (coeffs r, void*);
 number nrnMapGMP(number from, const coeffs /*src*/, const coeffs dst);/*for SAGE*/


### PR DESCRIPTION
... instead of int. This is the type used everywhere else for the exponent,
e.g. for modExponent