### PR TITLE
[prototype] Improve performance of liftstd

### DIFF
--- a/kernel/GBEngine/kutil.h
+++ b/kernel/GBEngine/kutil.h
@@ -68,6 +68,12 @@ public:
   poly sig;   // the signature of the element
   poly p;       // Lm(p) \in currRing Tail(p) \in tailRing
   poly t_p;     // t_p \in tailRing: as monomials Lm(t_p) == Lm(p)
+  poly transformation_coeffs = NULL;
+  int transformation_coeffs_length = 0;
+  int transformation_coeffs_parts_length = 0;
+  number (*transformation_coeffs_parts_numbers)[1000];
+  poly (*transformation_coeffs_parts_lms)[1000];
+  poly (*transformation_coeffs_parts_divisor_transformation_coeffs)[1000];
   poly max_exp;     // p_GetMaxExpP(pNext(p))
   ring tailRing;
   long FDeg;    // pFDeg(p)


### PR DESCRIPTION
This PR drastically improves the performance of `liftstd` in cases where a lot of syzygies appear during the reductions.

Consider the following example:
```
LIB "random.lib";
// make random reproducible
system("random", 1);
system("--ticks-per-sec",1000);

int t;

ring R = 0,(x,y,z),(c,dp);
matrix A = randommat(30, 700, maxideal(1), 10);
// use redHoney (so A should not be homogeneous since in this case redHomog would be used)
A[1,1] = x^2;

t = timer;
matrix G1 = std(A);
print("computed std in " + string(timer - t) + " ms");

matrix T;
t = timer;
matrix G2 = liftstd(A, T);
print("computed liftstd in " + string(timer - t) + " ms");
```

Without the PR, I get the following runtimes:
```
computed std in 2300 ms
computed liftstd in 9910 ms
```
so `liftstd` is slower than `std` by more than a factor of 4.

With the PR, I get the following runtimes (of course I have verified that I get the same Groebner basis `G2` and transformation matrix `T`):
```
computed std in 2400 ms
computed liftstd in 2810 ms
```
so `liftstd` only takes 17% longer than `std`. 

If I create `A` with more than 30 rows, the relative improvement gets even larger. In particular, `liftstd` now has the runtime I expected in #925, namely the runtime of "`std` + some bookkeeping".

# Why is `liftstd` slow in this example?

The columns of the input matrix `A` define polynomials/vectors `p_i`. We want to compute a Groebner basis `G` of the ideal/module generated by the `p_i`, together with a transformation matrix `T` such that `A * T == G`. To this end, `liftstd` puts an identity matrix below `A` to which the standard Groebner basis algorithm is applied (with some optimizations to not compute a Groebner basis below the lines corresponding to `A`). So the standard Groebner basis algorithm now does the reductions with very long vectors: the original vectors `p_i` + the transformation part, which is the sparse identity matrix at the beginning of the alorithm but quickly fills up. Of course, this is expected at first: if we want to compute the transformation matrix, we have to deal with long vectors. However, this approach also needlessly computes all the syzygies: It does the reductions with the long vectors, and if it sees that the components of the result corresponding to the actual Groebner basis are 0 (i.e., the transformation part is a syzygy), it throws the result away. Thus, it is much more efficient to compute the transformation part lazily: do the reductions with the short vectors, record the coefficients used during the reduction, and compute the transformation part of the result if (and only if) we do not have a syzygy.

# Details of the code of the PR

1. In `bba`, before a polynomial `P` (in the following called the dividend) is reduced, its transformation part (which might be distributed among the various buckets) is extracted and stored in `P.transformation_coeffs`.
2. Now, every time the dividend `PR` is reduced by a divisor `PW` via `P = LC(PW)*PR - LT(PR)/LM(PW)*PW` in `ksReducePoly` do the following:
    1. Extract the transformation part of `PW` and store it in `PW.transformation_coeffs`.
    2. Compute the reduced polynomial `P` as before.
    3. Add the number `LC(PW)` and the polynomials `LT(PR)/LM(PW)` and `PW.transformation_coeffs` to the arrays `PR->transformation_coeffs_parts_numbers`, `PR->transformation_coeffs_parts_lms` and `PR->transformation_coeffs_parts_divisor_transformation_coeffs`.
    4. Reattach the transformation part of the divisor stored in `PW.transformation_coeffs` to `PW`.
3. If after the reductions we do not have a syzygy: compute the transformation part of the result using the information stored in `P.transformation_coeffs_parts_numbers`, `P.transformation_coeffs_parts_lms` and `P.transformation_coeffs_parts_divisor_transformation_coeffs` and attach it to the result.

# State of the PR

This PR is only a prototype: it has many unhandled cases (some being caught explicitly in the code) and is only implemented for `bba` and `ksReducePoly`. Also, one could probably improve the performance even more by keeping the transformation part separate during the whole algorithm instead of extracting it before the reduction and reattaching it afterwards.

Currently, I do not need this improvement anymore (as I have moved the bottlenecks in my computations away from `liftstd`) and I certainly lack the knowledge of Singular to implement all of this properly. But if anyone with a deeper knowledge of Singular is interested in this, I would be happy to work together to actually get this working beyond a prototype :-)