### PR TITLE
Add no_rebase to libpolys's Makefile.am

### DIFF
--- a/libpolys/Makefile.am
+++ b/libpolys/Makefile.am
@@ -81,7 +81,7 @@ LIBPOLYSHEADERS = polys/monomials/ring.h polys/monomials/monomials.h \
         coeffs/flintcf_Qrat.h coeffs/flintcf_Q.h coeffs/flintcf_Zn.h
 
 libpolys_la_includedir  =$(includedir)/singular
-libpolys_la_include_HEADERS=${LIBPOLYSHEADERS}
+nobase_libpolys_la_include_HEADERS=${LIBPOLYSHEADERS}
 
 EXTRA_DIST = \
 	polys/prCopy.pl polys/prCopyTemplate.cc \


### PR DESCRIPTION
The restructuring of libpolys had the effect that all the header files were
installed into a flat directory, instead of conserving the directory structure.
This makes no difference to compiling the Singular binary, but when trying to
link against the libsingular.la library, this lead to the unfortunate problem,
that, for instance,

    #include <misc/auxiliary.h>

would fail, as auxiliary.h was never installed in a directoy named misc.