### PR TITLE
More dllexport for pynac

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -52,8 +52,8 @@ env:
   SPKG:        singular
   # Sage distribution packages to build
   TARGETS_PRE: build/make/Makefile
-  TARGETS:     SAGE_CHECK=yes singular
-  TARGETS_OPTIONAL: SAGE_CHECK=warn pynac pysingular
+  TARGETS:     SAGE_CHECK=yes singular pynac
+  TARGETS_OPTIONAL: SAGE_CHECK=warn pysingular
   # Standard setting: Test the current beta release of Sage:
   SAGE_REPO:   sagemath/sage
   SAGE_REF:    develop

--- a/factory/canonicalform.h
+++ b/factory/canonicalform.h
@@ -205,22 +205,22 @@ public:
 CF_INLINE CanonicalForm
 operator + ( const CanonicalForm&, const CanonicalForm& );
 
-CF_NO_INLINE CanonicalForm
+CF_NO_INLINE FACTORY_PUBLIC CanonicalForm
 operator - ( const CanonicalForm&, const CanonicalForm& );
 
 CF_INLINE CanonicalForm
 operator * ( const CanonicalForm&, const CanonicalForm& );
 
-CF_NO_INLINE CanonicalForm
+CF_NO_INLINE FACTORY_PUBLIC CanonicalForm
 operator / ( const CanonicalForm&, const CanonicalForm& );
 
-CF_NO_INLINE CanonicalForm
+CF_NO_INLINE FACTORY_PUBLIC CanonicalForm
 operator % ( const CanonicalForm&, const CanonicalForm& );
 
-CF_NO_INLINE CanonicalForm
+CF_NO_INLINE FACTORY_PUBLIC CanonicalForm
 div ( const CanonicalForm&, const CanonicalForm& );
 
-CF_NO_INLINE CanonicalForm
+CF_NO_INLINE FACTORY_PUBLIC CanonicalForm
 mod ( const CanonicalForm&, const CanonicalForm& );
 
 /*ENDPUBLIC*/


### PR DESCRIPTION
https://github.com/pynac/pynac uses Singular's libfactory. For the build to go through on Cygwin, we need some more `dllexport`.

