### PR TITLE
m4/flint-check.m4: Remove setting of shell variable AM_LDFLAGS

### DIFF
--- a/m4/flint-check.m4
+++ b/m4/flint-check.m4
@@ -63,7 +63,6 @@ if test "x$flint_found" = "xno" ; then
 
 		FLINT_CFLAGS="-I${FLINT_HOME}/include/"
 		FLINT_LIBS="-L${FLINT_HOME}/lib -Wl,-rpath -Wl,${FLINT_HOME}/lib -lflint -lmpfr -lgmp"
-		AM_LDFLAGS+="-rpath ${FLINT_HOME}/lib"
 
 	# we suppose that mpfr and mpir to be in the same place or available by default
 		CFLAGS="${BACKUP_CFLAGS} ${FLINT_CFLAGS} ${GMP_CPPFLAGS}"


### PR DESCRIPTION
This line does not do anything useful (as looking at the generated `configure` script will reveal) but it causes the repeated warnings in the bootstrapping phase
```
../m4/flint-check.m4:66: warning: macro 'AM_LDFLAGS' not found in library
```
