### PR TITLE
Make sure ownership of the content of the doc tarball is not preserve…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,7 @@ bin_SCRIPTS = libsingular-config
 
 install-data-local:
 	if test -e $(srcdir)/doc/doc.tbz2; then\
-	  (cat ${top_srcdir}/doc/doc.tbz2| (cd $(DESTDIR)$(datadir)/singular; tar jxf -));\
+	  (cat ${top_srcdir}/doc/doc.tbz2| (cd $(DESTDIR)$(datadir)/singular; tar -jx --no-same-owner -f -));\
 	   mkdir $(DESTDIR)$(datadir)/info;\
 	   mkdir $(DESTDIR)$(datadir)/doc;\
 	   mv  $(DESTDIR)$(datadir)/singular/singular.hlp  $(DESTDIR)$(datadir)/info/.;\


### PR DESCRIPTION
…d when installing as root.

This is a minor fix for https://www.singular.uni-kl.de:8005/trac/ticket/843. While it is disregarded as an issue in the ticket, it is
1. a QA issue for linux distribution
2. there is no guarantee that the content will remain accessible as it is in the future. Security improvement and various acl may make special sense of that ownership at some point.
3. a fix is trivial