### PR TITLE
gfanlib/Makefile.am: Build libgfan as a libtool convenience library

### DIFF
--- a/Singular/dyn_modules/gfanlib/Makefile.am
+++ b/Singular/dyn_modules/gfanlib/Makefile.am
@@ -40,5 +40,6 @@ endif
 endif
 
 if HAVE_GFANLIB
+# Use objects from the libtool convenience library
  gfanlib_la_LIBADD   += ${abs_top_builddir}/gfanlib/libgfan.la ${CDDGMPLDFLAGS}
 endif

--- a/gfanlib/Makefile.am
+++ b/gfanlib/Makefile.am
@@ -1,10 +1,9 @@
 ACLOCAL_AMFLAGS = -I ../m4
 
-if HAVE_GFANLIB
-  lib_LTLIBRARIES=libgfan.la
-endif
-
-libgfandir = $(libdir)
+# We build libgfan as a libtool convenience library.
+# It is not installed; instead, its objects will be spliced into the
+# module Singular/dyn_modules/gfanlib
+noinst_LTLIBRARIES = libgfan.la
 
 AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir} -DGMPRATIONAL
 
@@ -16,11 +15,8 @@ AM_CXXFLAGS = @CXX11_FLAG@
 
 SOURCES = gfanlib_circuittableint.cpp gfanlib_mixedvolume.cpp gfanlib_paralleltraverser.cpp gfanlib_polyhedralfan.cpp gfanlib_polymakefile.cpp gfanlib_symmetriccomplex.cpp gfanlib_symmetry.cpp gfanlib_traversal.cpp gfanlib_zcone.cpp gfanlib_zfan.cpp
 libgfan_la_SOURCES = $(SOURCES)
-libgfan_la_LDFLAGS = $(SINGULAR_LDFLAGS) $(CDDGMPLDFLAGS) $(GMP_LIBS) -release ${PACKAGE_VERSION}
+libgfan_la_LDFLAGS = $(SINGULAR_LDFLAGS) $(CDDGMPLDFLAGS) $(GMP_LIBS)
 
-libgfan_includedir =$(includedir)/gfanlib
-libgfan_include_HEADERS = config.h gfanlib_mixedvolume.h gfanlib_polymakefile.h gfanlib_symmetry.h gfanlib_vector.h gfanlib_z.h _config.h  gfanlib.h gfanlib_paralleltraverser.h gfanlib_q.h  gfanlib_traversal.h gfanlib_zcone.h gfanlib_circuittableint.h gfanlib_matrix.h gfanlib_polyhedralfan.h gfanlib_symmetriccomplex.h gfanlib_tropicalhomotopy.h gfanlib_zfan.h
+noinst_HEADERS = config.h gfanlib_mixedvolume.h gfanlib_polymakefile.h gfanlib_symmetry.h gfanlib_vector.h gfanlib_z.h _config.h  gfanlib.h gfanlib_paralleltraverser.h gfanlib_q.h  gfanlib_traversal.h gfanlib_zcone.h gfanlib_circuittableint.h gfanlib_matrix.h gfanlib_polyhedralfan.h gfanlib_symmetriccomplex.h gfanlib_tropicalhomotopy.h gfanlib_zfan.h
 
 DISTCLEANFILES =  config.h
-
-moduledir = $(libexecdir)/singular/MOD


### PR DESCRIPTION
I propose to change how the vendored library `libgfan` is built.
Currently, Singular builds it as an installed shared library -- which is problematic for downstream distributions that want to use the official gfanlib release tarball from Anders' gfan page.
This PR changes it to a libtool convenience library (and no longer installs the gfan headers). The objects in the convenience library are then spliced into the dyn_module gfanlib.