### PR TITLE
prefer cddlib/ over cdd/

### DIFF
--- a/Singular/dyn_modules/gfanlib/gfan.h
+++ b/Singular/dyn_modules/gfanlib/gfan.h
@@ -13,18 +13,20 @@ Author: monerjan
 #include "misc/int64vec.h"
 
 #include "gfanlib/config.h"
-#ifdef HAVE_CDD_SETOPER_H
-#include <cdd/setoper.h>
-#include <cdd/cdd.h>
-#include <cdd/cddmp.h>
-#elif HAVE_CDDLIB_SETOPER_H
+#ifdef HAVE_CDDLIB_SETOPER_H
 #include <cddlib/setoper.h>
 #include <cddlib/cdd.h>
 #include <cddlib/cddmp.h>
 #else
+#ifdef HAVE_CDD_SETOPER_H
+#include <cdd/setoper.h>
+#include <cdd/cdd.h>
+#include <cdd/cddmp.h>
+#else
 #include <setoper.h>
 #include <cdd.h>
 #include <cddmp.h>
+#endif
 #endif
 #include "bbfan.h"
 #include "bbcone.h"

--- a/gfanlib/gfanlib_zcone.cpp
+++ b/gfanlib/gfanlib_zcone.cpp
@@ -14,13 +14,13 @@
 #include <config.h>
 extern "C"
 {
-#ifdef HAVE_CDD_SETOPER_H
-#include <cdd/setoper.h>
-#include <cdd/cdd.h>
-#else
 #ifdef HAVE_CDDLIB_SETOPER_H
 #include <cddlib/setoper.h>
 #include <cddlib/cdd.h>
+#else
+#ifdef HAVE_CDD_SETOPER_H
+#include <cdd/setoper.h>
+#include <cdd/cdd.h>
 #else
 #include <setoper.h>
 #include <cdd.h>


### PR DESCRIPTION
An install from source of cdd will put the headers in `cddlib`. So this location folder should be the default place to look for.

Some systems put cdd in `usr/bin/cdd` (e.g. ubuntu bionic). If I have installed an updated cdd somewhere else, it is difficult to link this other one.

This patch will link the cdd installed from source anywhere, if it is early in my $PATH. I would argue that this is what I want in this case.

The downside is, that the system installed cdd will not be chosen anymore (depending on the system), if I also have a user installed cdd in my $PATH. (This could be fixed by enabling only one of `HAVE_CDDLIB_SETOPER_H` etc. according to the first element in my path with cdd.) However, this seems to be an unlikely scenario.