### PR TITLE
Bugfix for an indexing error

### DIFF
--- a/Singular/LIB/ncfactor.lib
+++ b/Singular/LIB/ncfactor.lib
@@ -7197,7 +7197,7 @@ ASSUMPTIONS:
   poly tempgcd;
   poly templhscoeff;
   poly temprhscoeff;
-  for (i = 2; i<=size(rhs);i++)
+  for (i = 1; i<=size(rhs);i++)
   {
     if (gcd(rhs[i][2],lhs[i][2]) == 1)
     {


### PR DESCRIPTION
I noticed that the polynomial
```
4z7d+84z6d+20z6+756z5d+372z5+3780z4d+z3d2+2880z4+11340z3d+6z2d2+11880z3+20413z2d+9zd2+27540z2+20421zd+34020z+8757d+17496
```
in the first Weyl algebra (z,d), which is reducable, was marked as having only one factorization. Going through the code I found that this was the error, leading Singular to believe that it had infinitely many factorizations to deal with.