### PR TITLE
configure: Options --with-XXX=DIR should override, not prepend to DEFAULT_CHECKING_PATH

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,7 @@ GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
 if test "$with_gmp" = yes ; then
 	GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
 elif test "$with_gmp" != no ; then
-	GMP_HOME_PATH="$with_gmp ${DEFAULT_CHECKING_PATH}"
+	GMP_HOME_PATH="$with_gmp"
 fi
 
 BACKUP_CFLAGS=${CFLAGS}
@@ -112,6 +112,7 @@ do
     if test -e ${GMP_HOME}/include/gmp.h; then
       GMP_CPPFLAGS="-I${GMP_HOME}/include"
       GMP_LIBS="-L${GMP_HOME}/lib -Wl,-rpath -Wl,${GMP_HOME}/lib -lgmp"
+      break
     fi
   fi
 done

--- a/factory/configure.ac
+++ b/factory/configure.ac
@@ -215,7 +215,7 @@ if test "${with_gmp+set}" = set; then :
   if test "$with_gmp" = yes ; then
 	GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
    elif test "$with_gmp" != no ; then
-	GMP_HOME_PATH="$with_gmp ${DEFAULT_CHECKING_PATH}"
+	GMP_HOME_PATH="$with_gmp"
     fi
 else
   GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"

--- a/libpolys/configure.ac
+++ b/libpolys/configure.ac
@@ -53,7 +53,7 @@ if test "${with_gmp+set}" = set; then :
   if test "$with_gmp" = yes ; then
 	GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
    elif test "$with_gmp" != no ; then
-	GMP_HOME_PATH="$with_gmp ${DEFAULT_CHECKING_PATH}"
+	GMP_HOME_PATH="$with_gmp"
     fi
 else
   GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"

--- a/m4/ccluster-check.m4
+++ b/m4/ccluster-check.m4
@@ -9,7 +9,7 @@ AC_ARG_WITH(ccluster,
 		[if test "$withval" = yes ; then
 			CCLUSTER_HOME_PATH="${DEFAULT_CHECKING_PATH}"
 	         elif test "$withval" != no ; then
-			CCLUSTERMP_HOME_PATH="$withval ${DEFAULT_CHECKING_PATH}"
+			CCLUSTERMP_HOME_PATH="$withval"
 	        fi],
 		[CCLUSTER_HOME_PATH="${DEFAULT_CHECKING_PATH}"])
 

--- a/m4/gfanlib-check.m4
+++ b/m4/gfanlib-check.m4
@@ -31,7 +31,7 @@ else
     if test "$with_gmp" = yes ; then
       GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
     elif test "$with_gmp" != no ; then
-      GMP_HOME_PATH="$with_gmp ${DEFAULT_CHECKING_PATH}"
+      GMP_HOME_PATH="$with_gmp"
     fi
 
     BACKUP_CFLAGS=${CFLAGS}


### PR DESCRIPTION
This change makes the handling of these options in all in the changed files (`configure.ac`, `factory/configure.ac`, `libpolys/configure.ac`, `m4/ccluster-check.m4`, `m4/gfanlib-check.m4`) consistent with `m4/flint-check.m4` and `m4/ntl-check.m4`.

Prior to this change, because the search loops do not use `break`, the explicitly passed directory `DIR` is not respected if an installation in one of the directories listed in `DEFAULT_CHECKING_PATH` is found.
