### PR TITLE
configure: More DEFAULT_CHECKING_PATH loop cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,7 +95,7 @@ AC_CHECK_LIB(rt,clock_gettime)
 # Check whether --with-gmp was given.
 AC_ARG_WITH([gmp],[AS_HELP_STRING([--with-gmp=path],
                     [provide a non-standard location of gmp])])
-DEFAULT_CHECKING_PATH="/usr /usr/local /sw /opt/local /opt/homebrew"
+DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
 GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
 if test "$with_gmp" = yes ; then
 	GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"

--- a/configure.ac
+++ b/configure.ac
@@ -92,44 +92,7 @@ AC_SUBST(CC)
 
 AC_CHECK_LIB(rt,clock_gettime)
 
-# Check whether --with-gmp was given.
-AC_ARG_WITH([gmp],[AS_HELP_STRING([--with-gmp=path],
-                    [provide a non-standard location of gmp])])
-DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
-GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
-if test "$with_gmp" = yes ; then
-	GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
-elif test "$with_gmp" != no ; then
-	GMP_HOME_PATH="$with_gmp"
-fi
-
-BACKUP_CFLAGS=${CFLAGS}
-BACKUP_LIBS=${LIBS}
-
-for GMP_HOME in ${GMP_HOME_PATH}
-do
-  if test "x$GMP_HOME" != "x/usr"; then
-    if test -e ${GMP_HOME}/include/gmp.h; then
-      GMP_CPPFLAGS="-I${GMP_HOME}/include"
-      GMP_LIBS="-L${GMP_HOME}/lib -Wl,-rpath -Wl,${GMP_HOME}/lib -lgmp"
-      break
-    fi
-  fi
-done
-if test -z "${GMP_LIBS}"
-then
-  GMP_LIBS="-lgmp"
-fi
-
-CFLAGS="${BACKUP_CFLAGS} ${GMP_CPPFLAGS}"
-LIBS=" ${GMP_LIBS} ${BACKUP_LIBS}"
-
-AC_SUBST(GMP_CPPFLAGS)
-AC_SUBST(GMP_LIBS)
-
-AC_CHECK_HEADERS([gmp.h], ,[AC_MSG_ERROR([GNU MP not found])])
-AC_CHECK_LIB(gmp, __gmpz_init, , [AC_MSG_ERROR([GNU MP not found])])
-
+SING_CHECK_GMP
 LB_CHECK_NTL(5.0,,AC_MSG_WARN([Unable to find NTL (which is strongly recommended) on your machine: please use --with-ntl=PATH_TO_DIR_CONTAINING_LIB_AND_INCLUDE (see also ./configure --help if you do not understand what we are talking about)]))
 LB_CHECK_FLINT(2.3,,AC_MSG_WARN([Unable to find FLINT (which is strongly recommended) on your machine: please use --with-flint=PATH_TO_DIR_CONTAINING_LIB_AND_INCLUDE (see also ./configure --help if you do not understand what we are talking about)]))
 

--- a/factory/configure.ac
+++ b/factory/configure.ac
@@ -208,43 +208,7 @@ DX_INIT_DOXYGEN($PACKAGE_NAME, doxygen.cfg, $srcdir/docu)
 AC_CHECK_LIB(m, atof, , [ AC_MSG_ERROR(libm.a not found) ])
 
 # Check whether --with-gmp was given.
-AC_ARG_WITH([gmp],[AS_HELP_STRING([--with-gmp=path],
-                    [provide a non-standard location of gmp])])
-DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
-if test "${with_gmp+set}" = set; then :
-  if test "$with_gmp" = yes ; then
-	GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
-   elif test "$with_gmp" != no ; then
-	GMP_HOME_PATH="$with_gmp"
-    fi
-else
-  GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
-fi
-
-BACKUP_CFLAGS=${CFLAGS}
-BACKUP_LIBS=${LIBS}
-
-for GMP_HOME in ${GMP_HOME_PATH}
-do
-  if test "x$GMP_HOME" != "x/usr"; then
-    if test -e ${GMP_HOME}/include/gmp.h; then
-      GMP_CPPFLAGS="-I${GMP_HOME}/include"
-      GMP_LIBS="-L${GMP_HOME}/lib -Wl,-rpath -Wl,${GMP_HOME}/lib -lgmp"
-      break
-    fi
-  fi
-  CFLAGS="${BACKUP_CFLAGS} ${GMP_CPPFLAGS}"
-  LIBS="${BACKUP_LIBS} ${GMP_LIBS}"
-done
-if test -z "${GMP_LIBS}"
-then
-  GMP_LIBS="-lgmp"
-fi
-AC_SUBST(GMP_CPPFLAGS)
-AC_SUBST(GMP_LIBS)
-
-AC_CHECK_HEADERS([gmp.h], ,[AC_MSG_ERROR([GNU MP not found])])
-AC_CHECK_LIB(gmp, __gmpz_init, , [AC_MSG_ERROR([GNU MP not found])])
+SING_CHECK_GMP
 
 #NTL 9.6.4 requires -lpthread/-pthread
 # This test for -lpthread etc has to come before AX_PTHREAD,

--- a/factory/configure.ac
+++ b/factory/configure.ac
@@ -210,7 +210,7 @@ AC_CHECK_LIB(m, atof, , [ AC_MSG_ERROR(libm.a not found) ])
 # Check whether --with-gmp was given.
 AC_ARG_WITH([gmp],[AS_HELP_STRING([--with-gmp=path],
                     [provide a non-standard location of gmp])])
-DEFAULT_CHECKING_PATH="/usr /usr/local /sw /opt/local /opt/homebrew"
+DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
 if test "${with_gmp+set}" = set; then :
   if test "$with_gmp" = yes ; then
 	GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
@@ -230,14 +230,16 @@ do
     if test -e ${GMP_HOME}/include/gmp.h; then
       GMP_CPPFLAGS="-I${GMP_HOME}/include"
       GMP_LIBS="-L${GMP_HOME}/lib -Wl,-rpath -Wl,${GMP_HOME}/lib -lgmp"
+      break
     fi
-  else
-    GMP_CPPFLAGS=""
-    GMP_LIBS="-lgmp"
   fi
   CFLAGS="${BACKUP_CFLAGS} ${GMP_CPPFLAGS}"
   LIBS="${BACKUP_LIBS} ${GMP_LIBS}"
 done
+if test -z "${GMP_LIBS}"
+then
+  GMP_LIBS="-lgmp"
+fi
 AC_SUBST(GMP_CPPFLAGS)
 AC_SUBST(GMP_LIBS)
 

--- a/libpolys/configure.ac
+++ b/libpolys/configure.ac
@@ -47,40 +47,7 @@ AC_SEARCH_LIBS(sem_wait,[rt pthreads pthread],[],[
 ])
 
 # Check whether --with-gmp was given.
-AC_ARG_WITH([gmp],[AS_HELP_STRING([--with-gmp=path],
-                    [provide a non-standard location of gmp])])
-if test "${with_gmp+set}" = set; then :
-  if test "$with_gmp" = yes ; then
-	GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
-   elif test "$with_gmp" != no ; then
-	GMP_HOME_PATH="$with_gmp"
-    fi
-else
-  GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
-fi
-
-BACKUP_CFLAGS=${CFLAGS}
-BACKUP_LIBS=${LIBS}
-
-for GMP_HOME in ${GMP_HOME_PATH}
-do
-  if test "x$GMP_HOME" != "x/usr"; then
-    if test -e ${GMP_HOME}/include/gmp.h; then
-      GMP_CPPFLAGS="-I${GMP_HOME}/include"
-      GMP_LIBS="-L${GMP_HOME}/lib -Wl,-rpath -Wl,${GMP_HOME}/lib -lgmp"
-      break
-    fi
-  fi
-done
-if test -z "${GMP_LIBS}"
-then
-  GMP_LIBS="-lgmp"
-fi
-
-CFLAGS="${BACKUP_CFLAGS} ${GMP_CPPFLAGS}"
-LIBS="${BACKUP_LIBS} ${GMP_LIBS}"
-AC_SUBST(GMP_CPPFLAGS)
-AC_SUBST(GMP_LIBS)
+SING_CHECK_GMP
 
 dnl ntl check in factory
 LB_CHECK_FLINT(2.4,,AC_MSG_WARN([Unable to find FLINT (which is strongly recommended) on your machine: please use --with-flint=PATH_TO_DIR_CONTAINING_LIB_AND_INCLUDE (see also ./configure --help if you do not understand what we are talking about)]))

--- a/libpolys/configure.ac
+++ b/libpolys/configure.ac
@@ -68,9 +68,15 @@ do
     if test -e ${GMP_HOME}/include/gmp.h; then
       GMP_CPPFLAGS="-I${GMP_HOME}/include"
       GMP_LIBS="-L${GMP_HOME}/lib -Wl,-rpath -Wl,${GMP_HOME}/lib -lgmp"
+      break
     fi
   fi
 done
+if test -z "${GMP_LIBS}"
+then
+  GMP_LIBS="-lgmp"
+fi
+
 CFLAGS="${BACKUP_CFLAGS} ${GMP_CPPFLAGS}"
 LIBS="${BACKUP_LIBS} ${GMP_LIBS}"
 AC_SUBST(GMP_CPPFLAGS)

--- a/m4/ccluster-check.m4
+++ b/m4/ccluster-check.m4
@@ -2,7 +2,7 @@
 
 AC_DEFUN([LB_CHECK_CCLUSTER],
 [
-DEFAULT_CHECKING_PATH="/usr /usr/local /sw /opt/local /opt/homebrew"
+DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
 
 AC_ARG_WITH(ccluster,
 [  --with-ccluster= <path>|yes Use ccluster library.  ],
@@ -34,7 +34,7 @@ for CCLUSTER_HOME in ${CCLUSTER_HOME_PATH}
 		LIBS="${BACKUP_LIBS} ${CCLUSTER_LIBS}"
 		AC_SUBST(CCLUSTER_LIBS)
 		AC_SUBST(CCLUSTER_CPPFLAGS)
-
+                break
 	fi
 done
 AC_LANG_POP([C])

--- a/m4/flint-check.m4
+++ b/m4/flint-check.m4
@@ -13,7 +13,7 @@ dnl FLINT_CFLAGS and FLINT_LIBS
 
 AC_DEFUN([LB_CHECK_FLINT],
 [
-DEFAULT_CHECKING_PATH="/usr /usr/local /sw /opt/local /opt/homebrew"
+DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
 
 AC_ARG_WITH(flint,
 [  --with-flint=<path>|yes|no  Use FLINT library. If argument is no, you do not have
@@ -73,6 +73,9 @@ if test "x$flint_found" = "xno" ; then
 		[],
 		[]
 		)
+                if test "x$flint_found" = "xyes" ; then
+                    break
+                  fi
 		fi
 	done
 fi

--- a/m4/gfanlib-check.m4
+++ b/m4/gfanlib-check.m4
@@ -26,31 +26,7 @@ else
   else
 
     # Check whether --with-gmp was given.
-    DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
-    GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
-    if test "$with_gmp" = yes ; then
-      GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
-    elif test "$with_gmp" != no ; then
-      GMP_HOME_PATH="$with_gmp"
-    fi
-
-    BACKUP_CFLAGS=${CFLAGS}
-    BACKUP_LIBS=${LIBS}
-
-    for GMP_HOME in ${GMP_HOME_PATH}
-    do
-      if test "x$GMP_HOME" != "x/usr"; then
-        if test -e ${GMP_HOME}/include/gmp.h; then
-          GMP_CPPFLAGS="-I${GMP_HOME}/include"
-          GMP_LIBS="-L${GMP_HOME}/lib -Wl,-rpath -Wl,${GMP_HOME}/lib -lgmp"
-          break
-        fi
-      fi
-    done
-    if test -z "${GMP_LIBS}"
-    then
-      GMP_LIBS="-lgmp"
-    fi
+    AC_REQUIRE([SING_CHECK_GMP])
 
     AC_LANG_PUSH(C++)
     AC_CHECK_LIB([cddgmp], [dd_free_global_constants],

--- a/m4/gfanlib-check.m4
+++ b/m4/gfanlib-check.m4
@@ -26,7 +26,7 @@ else
   else
 
     # Check whether --with-gmp was given.
-    DEFAULT_CHECKING_PATH="/usr /usr/local /sw /opt/local /opt/homebrew"
+    DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
     GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
     if test "$with_gmp" = yes ; then
       GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
@@ -43,6 +43,7 @@ else
         if test -e ${GMP_HOME}/include/gmp.h; then
           GMP_CPPFLAGS="-I${GMP_HOME}/include"
           GMP_LIBS="-L${GMP_HOME}/lib -Wl,-rpath -Wl,${GMP_HOME}/lib -lgmp"
+          break
         fi
       fi
     done

--- a/m4/gmp-check.m4
+++ b/m4/gmp-check.m4
@@ -1,0 +1,40 @@
+AC_DEFUN([SING_CHECK_GMP], [
+# Check whether --with-gmp was given.
+AC_ARG_WITH([gmp],[AS_HELP_STRING([--with-gmp=path],
+                    [provide a non-standard location of gmp])])
+DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
+GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
+if test "$with_gmp" = yes ; then
+        GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
+elif test "$with_gmp" != no ; then
+        GMP_HOME_PATH="$with_gmp"
+fi
+
+BACKUP_CFLAGS=${CFLAGS}
+BACKUP_LIBS=${LIBS}
+
+for GMP_HOME in ${GMP_HOME_PATH}
+do
+  if test "x$GMP_HOME" != "x/usr"; then
+    if test -e ${GMP_HOME}/include/gmp.h; then
+      GMP_CPPFLAGS="-I${GMP_HOME}/include"
+      GMP_LIBS="-L${GMP_HOME}/lib -Wl,-rpath -Wl,${GMP_HOME}/lib -lgmp"
+      break
+    fi
+  fi
+done
+if test -z "${GMP_LIBS}"
+then
+  GMP_LIBS="-lgmp"
+fi
+
+CFLAGS="${BACKUP_CFLAGS} ${GMP_CPPFLAGS}"
+LIBS=" ${GMP_LIBS} ${BACKUP_LIBS}"
+
+AC_SUBST(GMP_CPPFLAGS)
+AC_SUBST(GMP_LIBS)
+
+AC_CHECK_HEADERS([gmp.h], ,[AC_MSG_ERROR([GNU MP not found])])
+AC_CHECK_LIB(gmp, __gmpz_init, , [AC_MSG_ERROR([GNU MP not found])])
+
+])

--- a/m4/ntl-check.m4
+++ b/m4/ntl-check.m4
@@ -91,7 +91,6 @@ if test -r "$NTL_HOME/include/NTL/ZZ.h"; then
 	],
 	[
 	ntl_found="no"
-	ntl_checked="$checked $NTL_HOME"
 	unset NTL_CPPFLAGS
 	unset NTL_LIBS
 	])
@@ -134,7 +133,6 @@ dnl try again with -std=c++11 (for NTL >=10 with threads)
 	],
 	[
 	ntl_found="no"
-	ntl_checked="$checked $NTL_HOME"
 	unset NTL_CPPFLAGS
 	unset NTL_LIBS
 	])

--- a/m4/ntl-check.m4
+++ b/m4/ntl-check.m4
@@ -15,7 +15,7 @@ dnl NTL_CPPFLAGS and NTL_LIBS
 
 AC_DEFUN([LB_CHECK_NTL],
 [
-DEFAULT_CHECKING_PATH="/usr /usr/local /sw /opt/local /opt/homebrew"
+DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
 
 AC_ARG_WITH(ntl,
 [  --with-ntl=<path>|yes|no  Use NTL library. If argument is no, you do not have

--- a/m4/readline-check.m4
+++ b/m4/readline-check.m4
@@ -2,7 +2,6 @@
 
 AC_DEFUN([SING_CHECK_READLINE],
 [
-## DEFAULT_CHECKING_PATH="/usr /usr/local /sw /opt/local"
 
 #AC_ARG_WITH([readline],
 #  [AS_HELP_STRING([--without-readline],


### PR DESCRIPTION
This is cleanup which removes some code duplication, introducing a new file m4/gmp-check.m4, and simplifying the checking logic. It should be neutral in terms of functionality. 
Related Sage ticket: https://trac.sagemath.org/ticket/31592