### PR TITLE
Replace '-Wl,-rpath -Wl,...' by '-Wl,-rpath,...'

### DIFF
--- a/m4/ccluster-check.m4
+++ b/m4/ccluster-check.m4
@@ -27,7 +27,7 @@ for CCLUSTER_HOME in ${CCLUSTER_HOME_PATH}
 	        AC_MSG_RESULT(found)
 
 	        CCLUSTER_CPPFLAGS="-I${CCLUSTER_HOME}/include/ccluster"
-		CCLUSTER_LIBS="-L${CCLUSTER_HOME}/lib -Wl,-rpath -Wl,${CCLUSTER_HOME}/lib -lccluster"
+		CCLUSTER_LIBS="-L${CCLUSTER_HOME}/lib -Wl,-rpath,${CCLUSTER_HOME}/lib -lccluster"
 		AC_DEFINE(HAVE_CCLUSTER,1,[Define if Ccluster is installed])
 
 		CFLAGS="${BACKUP_CFLAGS} ${CCLUSTER_CPPFLAGS}"

--- a/m4/flint-check.m4
+++ b/m4/flint-check.m4
@@ -62,7 +62,7 @@ if test "x$flint_found" = "xno" ; then
 		if test -r "$FLINT_HOME/include/flint/fmpz.h"; then
 
 		FLINT_CFLAGS="-I${FLINT_HOME}/include/"
-		FLINT_LIBS="-L${FLINT_HOME}/lib -Wl,-rpath -Wl,${FLINT_HOME}/lib -lflint -lmpfr -lgmp"
+		FLINT_LIBS="-L${FLINT_HOME}/lib -Wl,-rpath,${FLINT_HOME}/lib -lflint -lmpfr -lgmp"
 
 	# we suppose that mpfr and mpir to be in the same place or available by default
 		CFLAGS="${BACKUP_CFLAGS} ${FLINT_CFLAGS} ${GMP_CPPFLAGS}"

--- a/m4/gmp-check.m4
+++ b/m4/gmp-check.m4
@@ -18,7 +18,7 @@ do
   if test "x$GMP_HOME" != "x/usr"; then
     if test -e ${GMP_HOME}/include/gmp.h; then
       GMP_CPPFLAGS="-I${GMP_HOME}/include"
-      GMP_LIBS="-L${GMP_HOME}/lib -Wl,-rpath -Wl,${GMP_HOME}/lib -lgmp"
+      GMP_LIBS="-L${GMP_HOME}/lib -Wl,-rpath,${GMP_HOME}/lib -lgmp"
       break
     fi
   fi

--- a/ppcc/autosetup/cc-shared.tcl
+++ b/ppcc/autosetup/cc-shared.tcl
@@ -28,7 +28,7 @@ define SHOBJ_LDFLAGS -shared
 define SH_CFLAGS -fPIC
 define SH_LDFLAGS -shared
 define SH_LINKFLAGS -rdynamic
-define SH_LINKRPATH "-Wl,-rpath -Wl,%s"
+define SH_LINKRPATH "-Wl,-rpath,%s"
 define SH_SOEXT .so
 define SH_SOEXTVER .so.%s
 define SH_SOPREFIX -Wl,-soname,


### PR DESCRIPTION
We have received a report (https://trac.sagemath.org/ticket/31592) that some versions of libtool may manipulate the order of linker options in a way that multiple given '-Wl,-rpath -Wl,...' options lead to invalid linker command lines.
In this PR I propose to change all uses of `-Wl,-rpath -Wl,...` (two args) to a format that is immune to reordering.