### PR TITLE
m4/*.m4: Define DEFAULT_CHECKING_PATH once only

### DIFF
--- a/m4/ccluster-check.m4
+++ b/m4/ccluster-check.m4
@@ -2,7 +2,7 @@
 
 AC_DEFUN([LB_CHECK_CCLUSTER],
 [
-DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
+AC_REQUIRE([SING_DEFAULT_CHECKING_PATH])
 
 AC_ARG_WITH(ccluster,
 [  --with-ccluster= <path>|yes Use ccluster library.  ],

--- a/m4/default_checking_path.m4
+++ b/m4/default_checking_path.m4
@@ -1,0 +1,3 @@
+AC_DEFUN([SING_DEFAULT_CHECKING_PATH], [
+    DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
+])

--- a/m4/flint-check.m4
+++ b/m4/flint-check.m4
@@ -13,7 +13,7 @@ dnl FLINT_CFLAGS and FLINT_LIBS
 
 AC_DEFUN([LB_CHECK_FLINT],
 [
-DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
+AC_REQUIRE([SING_DEFAULT_CHECKING_PATH])
 
 AC_ARG_WITH(flint,
 [  --with-flint=<path>|yes|no  Use FLINT library. If argument is no, you do not have

--- a/m4/gmp-check.m4
+++ b/m4/gmp-check.m4
@@ -2,7 +2,7 @@ AC_DEFUN([SING_CHECK_GMP], [
 # Check whether --with-gmp was given.
 AC_ARG_WITH([gmp],[AS_HELP_STRING([--with-gmp=path],
                     [provide a non-standard location of gmp])])
-DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
+AC_REQUIRE([SING_DEFAULT_CHECKING_PATH])
 GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
 if test "$with_gmp" = yes ; then
         GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"

--- a/m4/ntl-check.m4
+++ b/m4/ntl-check.m4
@@ -15,7 +15,7 @@ dnl NTL_CPPFLAGS and NTL_LIBS
 
 AC_DEFUN([LB_CHECK_NTL],
 [
-DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
+AC_REQUIRE([SING_DEFAULT_CHECKING_PATH])
 
 AC_ARG_WITH(ntl,
 [  --with-ntl=<path>|yes|no  Use NTL library. If argument is no, you do not have


### PR DESCRIPTION
Simple refactoring, which should be neutral in terms of functionality.
