### PR TITLE
m4/*.m4: In the search loops, test for the presence of headers using the compiler

### DIFF
--- a/m4/flint-check.m4
+++ b/m4/flint-check.m4
@@ -46,13 +46,11 @@ if test "$FLINT_HOME_PATH" = "$DEFAULT_CHECKING_PATH" ; then
 	CFLAGS=" ${GMP_CPPFLAGS} ${BACKUP_CFLAGS}"
 	LIBS="${FLINT_LIBS} ${GMP_LIBS} ${BACKUP_LIBS}"
 
-	AC_CHECK_HEADER([flint/fmpz.h],
-		[AC_CHECK_LIB(flint,fmpz_init,
-			[flint_found="yes"],
-			[],
-			[])],
-		[],
-		[])
+        AC_TRY_LINK([#include <flint/fmpz.h>
+                    ],
+                    [fmpz_t x; fmpz_init(x);], [
+                flint_found="yes"
+        ])
 fi
 
 dnl if flint was not previously found, search FLINT_HOME_PATH
@@ -67,16 +65,12 @@ if test "x$flint_found" = "xno" ; then
 		CFLAGS="${FLINT_CFLAGS} ${GMP_CPPFLAGS} ${BACKUP_CFLAGS}"
 		LIBS="${FLINT_LIBS} ${GMP_LIBS} ${BACKUP_LIBS}"
 
-                AC_CHECK_HEADER([flint/fmpz.h], [
-		AC_CHECK_LIB(flint,fmpz_init,
-		[flint_found="yes"],
-		[],
-		[]
-		)
+                AC_TRY_LINK([#include <flint/fmpz.h>
+                            ],
+                            [fmpz_t x; fmpz_init(x);], [
+                        flint_found="yes"
+                        break
                 ])
-                if test "x$flint_found" = "xyes" ; then
-                    break
-                  fi
 	done
 fi
 

--- a/m4/flint-check.m4
+++ b/m4/flint-check.m4
@@ -43,7 +43,7 @@ if test "$FLINT_HOME_PATH" = "$DEFAULT_CHECKING_PATH" ; then
 	FLINT_LIBS="-lflint -lmpfr -lgmp"
 
 	# we suppose that mpfr and mpir to be in the same place or available by default
-	CFLAGS="${BACKUP_CFLAGS} ${GMP_CPPFLAGS}"
+	CFLAGS=" ${GMP_CPPFLAGS} ${BACKUP_CFLAGS}"
 	LIBS="${FLINT_LIBS} ${GMP_LIBS} ${BACKUP_LIBS}"
 
 	AC_CHECK_HEADER([flint/fmpz.h],
@@ -59,24 +59,24 @@ dnl if flint was not previously found, search FLINT_HOME_PATH
 if test "x$flint_found" = "xno" ; then
 	for FLINT_HOME in ${FLINT_HOME_PATH}
 	do
-		if test -r "$FLINT_HOME/include/flint/fmpz.h"; then
 
 		FLINT_CFLAGS="-I${FLINT_HOME}/include/"
 		FLINT_LIBS="-L${FLINT_HOME}/lib -Wl,-rpath,${FLINT_HOME}/lib -lflint -lmpfr -lgmp"
 
 	# we suppose that mpfr and mpir to be in the same place or available by default
-		CFLAGS="${BACKUP_CFLAGS} ${FLINT_CFLAGS} ${GMP_CPPFLAGS}"
+		CFLAGS="${FLINT_CFLAGS} ${GMP_CPPFLAGS} ${BACKUP_CFLAGS}"
 		LIBS="${FLINT_LIBS} ${GMP_LIBS} ${BACKUP_LIBS}"
 
+                AC_CHECK_HEADER([flint/fmpz.h], [
 		AC_CHECK_LIB(flint,fmpz_init,
 		[flint_found="yes"],
 		[],
 		[]
 		)
+                ])
                 if test "x$flint_found" = "xyes" ; then
                     break
                   fi
-		fi
 	done
 fi
 

--- a/m4/gmp-check.m4
+++ b/m4/gmp-check.m4
@@ -13,28 +13,30 @@ fi
 BACKUP_CFLAGS=${CFLAGS}
 BACKUP_LIBS=${LIBS}
 
+gmp_found=no
 for GMP_HOME in ${GMP_HOME_PATH}
 do
-  if test "x$GMP_HOME" != "x/usr"; then
-    if test -e ${GMP_HOME}/include/gmp.h; then
+    if test "x$GMP_HOME" != "x/usr"; then
       GMP_CPPFLAGS="-I${GMP_HOME}/include"
       GMP_LIBS="-L${GMP_HOME}/lib -Wl,-rpath,${GMP_HOME}/lib -lgmp"
-      break
+      CFLAGS="${GMP_CPPFLAGS} ${BACKUP_CFLAGS}"
+      LIBS=" ${GMP_LIBS} ${BACKUP_LIBS}"
+    else
+      GMP_CPPFLAGS=""
+      GMP_LIBS="-lgmp"
     fi
-  fi
+    AC_CHECK_HEADERS([gmp.h], [
+      AC_CHECK_LIB(gmp, __gmpz_init, [
+        gmp_found=yes
+        break
+      ])
+    ])
 done
-if test -z "${GMP_LIBS}"
-then
-  GMP_LIBS="-lgmp"
+if test "$gmp_found" != yes; then
+    AC_MSG_ERROR([GNU MP not found])
 fi
-
-CFLAGS="${BACKUP_CFLAGS} ${GMP_CPPFLAGS}"
-LIBS=" ${GMP_LIBS} ${BACKUP_LIBS}"
 
 AC_SUBST(GMP_CPPFLAGS)
 AC_SUBST(GMP_LIBS)
-
-AC_CHECK_HEADERS([gmp.h], ,[AC_MSG_ERROR([GNU MP not found])])
-AC_CHECK_LIB(gmp, __gmpz_init, , [AC_MSG_ERROR([GNU MP not found])])
 
 ])

--- a/m4/gmp-check.m4
+++ b/m4/gmp-check.m4
@@ -25,11 +25,9 @@ do
       GMP_CPPFLAGS=""
       GMP_LIBS="-lgmp"
     fi
-    AC_CHECK_HEADERS([gmp.h], [
-      AC_CHECK_LIB(gmp, __gmpz_init, [
-        gmp_found=yes
-        break
-      ])
+    AC_TRY_LINK([#include <gmp.h>],
+                [mpz_t a; mpz_init (a);], [
+      gmp_found=yes
     ])
 done
 if test "$gmp_found" != yes; then

--- a/m4/gmp-check.m4
+++ b/m4/gmp-check.m4
@@ -1,14 +1,20 @@
 AC_DEFUN([SING_CHECK_GMP], [
+AC_REQUIRE([SING_DEFAULT_CHECKING_PATH])
 # Check whether --with-gmp was given.
 AC_ARG_WITH([gmp],[AS_HELP_STRING([--with-gmp=path],
-                    [provide a non-standard location of gmp])])
-AC_REQUIRE([SING_DEFAULT_CHECKING_PATH])
-GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
+                    [provide a non-standard location of gmp])], [
+    dnl Given
 if test "$with_gmp" = yes ; then
         GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
 elif test "$with_gmp" != no ; then
         GMP_HOME_PATH="$with_gmp"
+else
+     AC_MSG_ERROR([Use of GNU MP is required, cannot use --without-gmp])
 fi
+], [
+    dnl Not given
+    GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
+])
 
 BACKUP_CFLAGS=${CFLAGS}
 BACKUP_LIBS=${LIBS}
@@ -25,7 +31,8 @@ do
       GMP_CPPFLAGS=""
       GMP_LIBS="-lgmp"
     fi
-    AC_TRY_LINK([#include <gmp.h>],
+    AC_TRY_LINK([#include <gmp.h>
+                ],
                 [mpz_t a; mpz_init (a);], [
       gmp_found=yes
     ])

--- a/m4/ntl-check.m4
+++ b/m4/ntl-check.m4
@@ -49,19 +49,14 @@ fi
 
 for NTL_HOME in ${NTL_HOME_PATH}
  do
-if test -r "$NTL_HOME/include/NTL/ZZ.h"; then
-
 	if test "x$NTL_HOME" != "x/usr"; then
-	  if test -e  $NTL_HOME/include/NTL/mat_ZZ.h; then
 		NTL_CPPFLAGS="-I${NTL_HOME}/include"
 		NTL_LIBS="-L${NTL_HOME}/lib -lntl"
-	  fi
 	else
 		NTL_CPPFLAGS=""
 		NTL_LIBS="-lntl"
 	fi
-###	CFLAGS="${BACKUP_CFLAGS} ${NTL_CPPFLAGS} ${GMP_CPPFLAGS}"
-	CXXFLAGS="${BACKUP_CXXFLAGS} ${NTL_CPPFLAGS} ${GMP_CPPFLAGS}"
+	CXXFLAGS="${NTL_CPPFLAGS} ${GMP_CPPFLAGS} ${BACKUP_CXXFLAGS}"
 	LIBS="${NTL_LIBS} ${GMP_LIBS} ${BACKUP_LIBS}"
 
 	AC_TRY_LINK(
@@ -102,9 +97,8 @@ dnl try again with -std=c++11 (for NTL >=10 with threads)
 		NTL_CPPFLAGS="-std=c++11"
 		NTL_LIBS="-lntl"
 	fi
-###	CFLAGS="${BACKUP_CFLAGS} ${NTL_CPPFLAGS} ${GMP_CPPFLAGS}"
-	CXXFLAGS="${BACKUP_CXXFLAGS} ${NTL_CPPFLAGS} ${GMP_CPPFLAGS}"
-	LIBS="${BACKUP_LIBS} ${NTL_LIBS} ${GMP_LIBS}"
+	CXXFLAGS="${NTL_CPPFLAGS} ${BACKUP_CXXFLAGS} ${GMP_CPPFLAGS}"
+	LIBS="${NTL_LIBS} ${GMP_LIBS} ${BACKUP_LIBS}"
 
 	AC_TRY_LINK(
 	[#include <NTL/ZZ.h>],
@@ -136,9 +130,6 @@ dnl try again with -std=c++11 (for NTL >=10 with threads)
 	unset NTL_CPPFLAGS
 	unset NTL_LIBS
 	])
-else
-	ntl_found="no"
-fi
 done
 
 if test "x$ntl_found" = "xyes" ; then


### PR DESCRIPTION
... using `AC_CHECK_HEADERS` instead of just testing the presence of a file.

I have made these changes for FLINT, GMP, and NTL. 
I have not made any changes to `m4/ccluster-check.m4`.