### PR TITLE
m4/flint-check.m4: Refactor

### DIFF
--- a/m4/flint-check.m4
+++ b/m4/flint-check.m4
@@ -16,19 +16,19 @@ AC_DEFUN([LB_CHECK_FLINT],
 AC_REQUIRE([SING_DEFAULT_CHECKING_PATH])
 
 AC_ARG_WITH(flint,
-[  --with-flint=<path>|yes|no  Use FLINT library. If argument is no, you do not have
-                            the library installed on your machine (set as
-			    default). If argument is yes or <empty> that means
-			    the library is reachable with the standard search
-			    path (/usr or /usr/local). Otherwise you give the
-			    <path> to the directory which contain the library.
+[  --with-flint=<path>|yes|no  Use FLINT library. By default (yes), Singular will
+                            try to find the library and use it if found.
+                            If argument is no, Singular will not use the
+                            library even if it could be found on your machine.
+                            Otherwise you can give the <path> to the directory
+                            which contains the library.
 	     ],
 	     [if test "x$withval" = xyes ; then
-			FLINT_HOME_PATH="${DEFAULT_CHECKING_PATH}"
+			FLINT_HOME_PATH="DEFAULTS ${DEFAULT_CHECKING_PATH}"
 	      elif test "x$withval" != xno ; then
 			FLINT_HOME_PATH="$withval"
 	     fi],
-	     [FLINT_HOME_PATH="${DEFAULT_CHECKING_PATH}"])
+	     [FLINT_HOME_PATH="DEFAULTS ${DEFAULT_CHECKING_PATH}"])
 
 dnl Check for existence
 BACKUP_CFLAGS=${CFLAGS}
@@ -37,29 +37,16 @@ BACKUP_LIBS=${LIBS}
 AC_LANG_PUSH([C])
 
 flint_found="no"
-dnl check for system installed libraries if FLINT_HOME_PATH is the default
-if test "$FLINT_HOME_PATH" = "$DEFAULT_CHECKING_PATH" ; then
-	FLINT_CFLAGS=""
-	FLINT_LIBS="-lflint -lmpfr -lgmp"
-
-	# we suppose that mpfr and mpir to be in the same place or available by default
-	CFLAGS=" ${GMP_CPPFLAGS} ${BACKUP_CFLAGS}"
-	LIBS="${FLINT_LIBS} ${GMP_LIBS} ${BACKUP_LIBS}"
-
-        AC_TRY_LINK([#include <flint/fmpz.h>
-                    ],
-                    [fmpz_t x; fmpz_init(x);], [
-                flint_found="yes"
-        ])
-fi
-
 dnl if flint was not previously found, search FLINT_HOME_PATH
-if test "x$flint_found" = "xno" ; then
-	for FLINT_HOME in ${FLINT_HOME_PATH}
-	do
-
+for FLINT_HOME in ${FLINT_HOME_PATH}
+do
+        if test "$FLINT_HOME" = DEFAULTS; then
+                FLINT_CFLAGS=""
+                FLINT_LIBS="-lflint -lmpfr -lgmp"
+        else
 		FLINT_CFLAGS="-I${FLINT_HOME}/include/"
 		FLINT_LIBS="-L${FLINT_HOME}/lib -Wl,-rpath,${FLINT_HOME}/lib -lflint -lmpfr -lgmp"
+        fi
 
 	# we suppose that mpfr and mpir to be in the same place or available by default
 		CFLAGS="${FLINT_CFLAGS} ${GMP_CPPFLAGS} ${BACKUP_CFLAGS}"
@@ -71,8 +58,7 @@ if test "x$flint_found" = "xno" ; then
                         flint_found="yes"
                         break
                 ])
-	done
-fi
+done
 
 AC_LANG_POP([C])
 


### PR DESCRIPTION
We introduce a special element `DEFAULTS` as the first element of the default `FLINT_HOME_PATH`.
This allows us simplify the code from https://github.com/Singular/Singular/pull/981 @kiwifb, reducing code duplication.

This change should be neutral in terms of functionality.

We also update the help string of the `--with-flint` option so that the described behavior is closer to what is actually implemented.
