### PR TITLE
m4/*-check.m4: Check DEFAULTS first, following flint-check.m4

### DIFF
--- a/m4/ccluster-check.m4
+++ b/m4/ccluster-check.m4
@@ -7,11 +7,11 @@ AC_REQUIRE([SING_DEFAULT_CHECKING_PATH])
 AC_ARG_WITH(ccluster,
 [  --with-ccluster= <path>|yes Use ccluster library.  ],
 		[if test "$withval" = yes ; then
-			CCLUSTER_HOME_PATH="${DEFAULT_CHECKING_PATH}"
+			CCLUSTER_HOME_PATH="${DEFAULT_CHECKING_PATH} /usr"
 	         elif test "$withval" != no ; then
-			CCLUSTERMP_HOME_PATH="$withval"
+			CCLUSTER_HOME_PATH="$withval"
 	        fi],
-		[CCLUSTER_HOME_PATH="${DEFAULT_CHECKING_PATH}"])
+		[CCLUSTER_HOME_PATH="${DEFAULT_CHECKING_PATH} /usr"])
 
 dnl Check for existence
 BACKUP_CFLAGS=${CFLAGS}

--- a/m4/default_checking_path.m4
+++ b/m4/default_checking_path.m4
@@ -1,3 +1,3 @@
 AC_DEFUN([SING_DEFAULT_CHECKING_PATH], [
-    DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local /usr"
+    DEFAULT_CHECKING_PATH="/opt/homebrew /opt/local /sw /usr/local"
 ])

--- a/m4/gmp-check.m4
+++ b/m4/gmp-check.m4
@@ -5,7 +5,7 @@ AC_ARG_WITH([gmp],[AS_HELP_STRING([--with-gmp=path],
                     [provide a non-standard location of gmp])], [
     dnl Given
 if test "$with_gmp" = yes ; then
-        GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
+        GMP_HOME_PATH="DEFAULTS ${DEFAULT_CHECKING_PATH}"
 elif test "$with_gmp" != no ; then
         GMP_HOME_PATH="$with_gmp"
 else
@@ -13,7 +13,7 @@ else
 fi
 ], [
     dnl Not given
-    GMP_HOME_PATH="${DEFAULT_CHECKING_PATH}"
+    GMP_HOME_PATH="DEFAULTS ${DEFAULT_CHECKING_PATH}"
 ])
 
 BACKUP_CFLAGS=${CFLAGS}
@@ -22,19 +22,20 @@ BACKUP_LIBS=${LIBS}
 gmp_found=no
 for GMP_HOME in ${GMP_HOME_PATH}
 do
-    if test "x$GMP_HOME" != "x/usr"; then
+    if test "$GMP_HOME" != "DEFAULTS"; then
       GMP_CPPFLAGS="-I${GMP_HOME}/include"
       GMP_LIBS="-L${GMP_HOME}/lib -Wl,-rpath,${GMP_HOME}/lib -lgmp"
-      CFLAGS="${GMP_CPPFLAGS} ${BACKUP_CFLAGS}"
-      LIBS=" ${GMP_LIBS} ${BACKUP_LIBS}"
     else
       GMP_CPPFLAGS=""
       GMP_LIBS="-lgmp"
     fi
+    CFLAGS="${GMP_CPPFLAGS} ${BACKUP_CFLAGS}"
+    LIBS=" ${GMP_LIBS} ${BACKUP_LIBS}"
     AC_TRY_LINK([#include <gmp.h>
                 ],
                 [mpz_t a; mpz_init (a);], [
       gmp_found=yes
+      break
     ])
 done
 if test "$gmp_found" != yes; then

--- a/m4/ntl-check.m4
+++ b/m4/ntl-check.m4
@@ -26,12 +26,12 @@ AC_ARG_WITH(ntl,
 			    <path> to the directory which contain the library.
 	     ],
 	     [if test "$withval" = yes ; then
-			NTL_HOME_PATH="${DEFAULT_CHECKING_PATH}"
+			NTL_HOME_PATH="DEFAULTS ${DEFAULT_CHECKING_PATH}"
 	      elif test "$withval" != no ; then
 			NTL_HOME_PATH="$withval"
 			NTL_SHOULD_BE_PRESENT="yes"
 	     fi],
-	     [NTL_HOME_PATH="${DEFAULT_CHECKING_PATH}"])
+	     [NTL_HOME_PATH="DEFAULTS ${DEFAULT_CHECKING_PATH}"])
 
 min_ntl_version=ifelse([$1], ,1.0,$1)
 
@@ -49,7 +49,7 @@ fi
 
 for NTL_HOME in ${NTL_HOME_PATH}
  do
-	if test "x$NTL_HOME" != "x/usr"; then
+	if test "$NTL_HOME" != "DEFAULTS"; then
 		NTL_CPPFLAGS="-I${NTL_HOME}/include"
 		NTL_LIBS="-L${NTL_HOME}/lib -lntl"
 	else

--- a/m4/ntl-check.m4
+++ b/m4/ntl-check.m4
@@ -90,7 +90,7 @@ for NTL_HOME in ${NTL_HOME_PATH}
 	unset NTL_LIBS
 	])
 dnl try again with -std=c++11 (for NTL >=10 with threads)
-	if test "x$NTL_HOME" != "x/usr"; then
+	if test "$NTL_HOME" != "DEFAULTS"; then
 		NTL_CPPFLAGS="-std=c++11 -I${NTL_HOME}/include"
 		NTL_LIBS="-L${NTL_HOME}/lib -lntl"
 	else


### PR DESCRIPTION
This removes /usr from the end of DEFAULT_CHECKING_PATH
and instead puts the special token DEFAULTS to the front
of NTL_HOME_PATH, GMP_HOME_PATH.

Because ccluster-check.m4 has not been switched to
compiler-based header file detection, we do not
change the search algorithm there.  We add /usr back
at the end of CCLUSTER_HOME_PATH to compensate for
the change of DEFAULT_CHECKING_PATH.
We also fix a typo that makes --with-ccluster=PATH
actually work (untested, as this library does not
seem available)