### PR TITLE
Docbuild fixes

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -57,10 +57,10 @@ env:
   # Standard setting: Test the current beta release of Sage:
   SAGE_REPO:   sagemath/sage
   SAGE_REF:    develop
-  # Temporarily test with the branch from sage ticket for singular 4.2 upgrade
+  # Temporarily test with the branch from a sage ticket with build script fixes
   # (this is a no-op after that ticket is merged)
   SAGE_TRAC_GIT: https://github.com/sagemath/sagetrac-mirror.git
-  SAGE_TICKET: 25993
+  SAGE_TICKET: 31592
   REMOVE_PATCHES: "*"
 
 jobs:

--- a/configure.ac
+++ b/configure.ac
@@ -316,6 +316,8 @@ AS_IF([test -z "$PYTHON"], [
 AC_CHECK_PROGS([FOURTITWO_HILBERT], [hilbert 4ti2-hilbert])
 AC_CHECK_PROGS([FOURTITWO_MARKOV], [markov 4ti2-markov])
 AC_CHECK_PROGS([FOURTITWO_GRAVER], [graver 4ti2-graver])
+AS_IF([test -z "$FOURTITWO_HILBERT" -o -z "$FOURTITWO_MARKOV" -o -z "$FOURTITWO_GRAVER"], [
+  AS_VAR_APPEND([DOC2TEX_EXAMPLE_EXCLUSIONS], ["-exclude sing4ti2 "])])
 AC_CHECK_PROGS([BERTINI], [bertini])
 AS_IF([test -z "$BERTINI"], [
   AS_VAR_APPEND([DOC2TEX_EXAMPLE_EXCLUSIONS], ["-exclude bertini "])])

--- a/configure.ac
+++ b/configure.ac
@@ -333,7 +333,9 @@ AC_CONFIG_LINKS([doc/pyobject.doc:doc/pyobject.${enable_pyobject_module}.doc
                  doc/cones.doc:doc/cones.no.doc])
 AC_ARG_ENABLE([doc-build],
               [AS_HELP_STRING([--enable-doc-build],
-                              [Enable building the Singular documentation])])
+                              [Enable building the Singular documentation])], [
+  AS_IF([test "$enable_doc_build" = yes], [optional_Singular_programs=libparse])
+])
 AM_CONDITIONAL([ENABLE_DOC_BUILD], [test "$enable_doc_build" = yes])
 
 AC_OUTPUT

--- a/doc/Makefile-docbuild.in
+++ b/doc/Makefile-docbuild.in
@@ -36,7 +36,7 @@ VERBOSE         = 1 # override this with make VERBOSE=2
 SINGULAR        = ${top_builddir}/Singular/Singular
 SINGULAR_LIB_DIR= ${top_srcdir}/Singular/LIB
 # from Singular/Makefile.am, extended by dynmodules stuff:
-TESTS_ENVIRONMENT = unset DISPLAY && SINGULARPATH="$$(for d in ${top_builddir}/Singular/dyn_modules/*/.libs; do printf $$d:; done)" PATH="${top_builddir}/IntegerProgramming:$$PATH"
+TESTS_ENVIRONMENT = unset DISPLAY SINGULAR_EXECUTABLE && SINGULARPATH="$$(for d in ${top_builddir}/Singular/dyn_modules/*/.libs; do printf $$d:; done)" PATH="${top_builddir}/IntegerProgramming:$$PATH"
 LIBPARSE        = ${top_builddir}/Singular/libparse${EXEEXT}
 DOC_SUBDIR      = ./d2t_singular
 EX_SUBDIR       = ./examples


### PR DESCRIPTION
Some fixes to improve the docbuild.

Note that even with commit 249b97d, the docbuild still fails when 4ti2 is not installed. It would be good if that could be fixed too.
```
**** Error: while running example cohomologyMatrix from d2t_singular/tateProdCplxNegGrad_lib.doc:360.
Call: '../Singular/Singular  -teqr12345678 --no-rc ./examples/cohomologyMatrix.sing > ./examples/cohomologyMatrix.res'
make[4]: *** [d2t_singular/tateProdCplxNegGrad_lib.tex] Error 1
```
