### PR TITLE
doc/Makefile-docbuild.in: Include .libs directories in PATH for Cygwin

### DIFF
--- a/doc/Makefile-docbuild.in
+++ b/doc/Makefile-docbuild.in
@@ -95,8 +95,9 @@ IMAGES     := $(IMAGES_UU:images/%.uu=%)
 IMAGES_SRC := $(IMAGES:%=images/%)
 IMAGES_HTML := $(IMAGES:%=${HTML_SUBDIR}/%)
 
-# prepend bindir to path so that programs from there are taken first
-export PATH := "${bindir}:${PATH}"
+# prepend bindir to path so that programs from there are taken first.
+# prepending the .libs directories is needed on Cygwin for finding the .dll files
+export PATH := "${bindir}:${top_builddir}/libpolys/polys/.libs:${top_builddir}/Singular/.libs:${top_builddir}/omalloc/.libs:${top_builddir}/factory/.libs:${PATH}"
 
 ###########################################################
 # top targets

--- a/doc/Makefile-docbuild.in
+++ b/doc/Makefile-docbuild.in
@@ -97,7 +97,7 @@ IMAGES_HTML := $(IMAGES:%=${HTML_SUBDIR}/%)
 
 # prepend bindir to path so that programs from there are taken first.
 # prepending the .libs directories is needed on Cygwin for finding the .dll files
-export PATH := "${bindir}:${top_builddir}/libpolys/polys/.libs:${top_builddir}/Singular/.libs:${top_builddir}/omalloc/.libs:${top_builddir}/factory/.libs:${PATH}"
+export PATH := "${bindir}:${top_builddir}/libpolys/polys/.libs:${top_builddir}/Singular/.libs:${top_builddir}/omalloc/.libs:${top_builddir}/factory/.libs:${top_builddir}/resources/.libs:${PATH}"
 
 ###########################################################
 # top targets


### PR DESCRIPTION
Without this fix, the (non-installed) DLLs for the various components of Singular are not found during the docbuild.
```
  [singular-git]   **** Error: Can�t run '../Singular/Singular.exe  -teqr12345678 --no-rc': make[4]: *** [Makefile-docbuild:179: plural.tex] Error 1
  [singular-git]   C:/tools/cygwin/opt/sage-singular-1583c8f3213c3d37c7272198b00d751bb851bf7d/var/tmp/sage/build/singular-git/src/Singular/Singular.exe: error while loading shared libraries: cygsingular_resources-4-2-0.dll: cannot open shared object file: No such file or directory
```
(from https://github.com/Singular/Singular/runs/2314281048)
