### PR TITLE
Fix spelling errors

### DIFF
--- a/Singular/links/ssiLink.cc
+++ b/Singular/links/ssiLink.cc
@@ -2034,7 +2034,7 @@ int ssiReservePort(int clients)
 {
   if (ssiReserved_P!=0)
   {
-    WerrorS("ERROR already a reverved port requested");
+    WerrorS("ERROR already a reserved port requested");
     return 0;
   }
   int portno;
@@ -2070,7 +2070,7 @@ si_link ssiCommandLink()
 {
   if (ssiReserved_P==0)
   {
-    WerrorS("ERROR no reverved port requested");
+    WerrorS("ERROR no reserved port requested");
     return NULL;
   }
   struct sockaddr_in cli_addr;

--- a/kernel/GBEngine/kChinese.cc
+++ b/kernel/GBEngine/kChinese.cc
@@ -269,7 +269,7 @@ ideal id_ChineseRemainder_0(ideal *xx, number *q, int rl, const ring r)
   }
   else // parent ---------------------------------------------------
   {
-    if (TEST_OPT_PROT) printf("%d childs created\n",cpus);
+    if (TEST_OPT_PROT) printf("%d children created\n",cpus);
     VRef<VString> msg;
     while(cnt>0)
     {
@@ -343,7 +343,7 @@ ideal id_Farey_0(ideal x, number N, const ring r)
   }
   else // parent ---------------------------------------------------
   {
-    if (TEST_OPT_PROT) printf("%d childs created\n",cpus);
+    if (TEST_OPT_PROT) printf("%d children created\n",cpus);
     VRef<VString> msg;
     while(cnt>0)
     {


### PR DESCRIPTION
These are causing [`spelling-error-in-binary`](https://lintian.debian.org/tags/spelling-error-in-binary) Lintian warnings in the Debian package.