### PR TITLE
gfanlib/Makefile.am: use LIBADD for additional libraries.

### DIFF
--- a/gfanlib/Makefile.am
+++ b/gfanlib/Makefile.am
@@ -18,8 +18,12 @@ AM_CXXFLAGS = @CXX11_FLAG@
 
 SOURCES = gfanlib_circuittableint.cpp gfanlib_mixedvolume.cpp gfanlib_paralleltraverser.cpp gfanlib_polyhedralfan.cpp gfanlib_polymakefile.cpp gfanlib_symmetriccomplex.cpp gfanlib_symmetry.cpp gfanlib_traversal.cpp gfanlib_zcone.cpp gfanlib_zfan.cpp
 libgfan_la_SOURCES = $(SOURCES)
-libgfan_la_LDFLAGS = $(SINGULAR_LDFLAGS) $(CDDGMPLDFLAGS) $(GMP_LIBS)
+libgfan_la_LDFLAGS = $(SINGULAR_LDFLAGS)
 libgfan_la_CPPFLAGS= $(GMP_CPPFLAGS) $(CDDGMPCPPFLAGS)
+
+# Despite the naming convention, $CDDGMPLDFLAGS contains "-lcddgmp"
+# and the rest of the $GMP_LIBS flags.
+libgfan_la_LIBADD = $(CDDGMPLDFLAGS) $(GMP_LIBS)
 
 noinst_HEADERS = config.h gfanlib_mixedvolume.h gfanlib_polymakefile.h gfanlib_symmetry.h gfanlib_vector.h gfanlib_z.h _config.h  gfanlib.h gfanlib_paralleltraverser.h gfanlib_q.h  gfanlib_traversal.h gfanlib_zcone.h gfanlib_circuittableint.h gfanlib_matrix.h gfanlib_polyhedralfan.h gfanlib_symmetriccomplex.h gfanlib_tropicalhomotopy.h gfanlib_zfan.h
 


### PR DESCRIPTION
The `$GMP_LIBS` and `$CDDGMPLDFLAGS` variables were being added to
`libgfan_la_LDFLAGS`, which isn't quite correct. Since both contain
library (-l) flags, they belong in `_LIBADD` rather than `_LDFLAGS`:

  https://www.gnu.org/software/automake/manual/html_node/Libtool-Flags.html

This commit moves them to a new `libgfan_la_LIBADD` variable.