### PR TITLE
configure.ac: replace double-equals bash comparison.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,7 +147,7 @@ AC_ARG_ENABLE(countedref, AS_HELP_STRING([--enable-countedref], [Enable autoload
 ENABLE_COUNTEDREF_AUTOLOAD=yes
 fi], ENABLE_COUNTEDREF_AUTOLOAD=no)
 
-if test x"${ENABLE_COUNTEDREF_AUTOLOAD}" == xyes; then
+if test x"${ENABLE_COUNTEDREF_AUTOLOAD}" = xyes; then
   AC_DEFINE([SI_COUNTEDREF_AUTOLOAD],1,[Enable autoloading of reference counted types])
   AC_SUBST(SI_COUNTEDREF_AUTOLOAD)
 fi


### PR DESCRIPTION
Replace a double-equals (bash-only) used for a string comparison with
its single-equals (POSIX compatible) counterpart. This fixes the
error,

  ./configure: 25804: test: xno: unexpected operator

observed when running ./configure with a non-bash /bin/sh, such
as dash.