### PR TITLE
Fix some autoconf-2.71 warnings

### DIFF
--- a/factory/configure.ac
+++ b/factory/configure.ac
@@ -261,8 +261,7 @@ fi
 
 if test "x$enable_timing" != xno; then
   AC_CHECK_HEADERS(sys/param.h sys/times.h, ,
-    [ AC_MSG_ERROR(\`sys/times.h' or \`sys/param.h' not found.  Try
-                  \`configure --disable-timing') ])
+    [ AC_MSG_ERROR(sys/times.h or sys/param.h not found, try --disable-timing) ])
 fi
 
 # font-lock-trick: '

--- a/m4/flags.m4
+++ b/m4/flags.m4
@@ -27,7 +27,7 @@ AC_MSG_RESULT(${CXX:-unset})
 ])
 
 AC_DEFUN([SING_RESET_FLAGS], [
- AC_MSG_WARN([Please note that we set empty defaults for \`CFLAGS' and \`CXXFLAGS' (instead of \`-g -O')])
+ AC_MSG_WARN([Please note that we set empty defaults for CFLAGS and CXXFLAGS])
  : ${CFLAGS:=""}
  : ${CXXFLAGS:=""}
 ])


### PR DESCRIPTION
Running `autoreconf -fi` spits out a number of warnings with the latest autoconf-2.71. Here I fix a few relatively trivial ones that can't be automatically addressed by running `autoupdate`.

