### PR TITLE
Always return a value in functions with non-void return type

### DIFF
--- a/Singular/dyn_modules/cohomo/cohomo.cc
+++ b/Singular/dyn_modules/cohomo/cohomo.cc
@@ -3943,6 +3943,7 @@ std::vector<std::vector<int> > links_new(poly a, ideal Xo, ideal Sigma, int vert
     return lkn;
   }
   WerrorS("Cannot find the links smartly!");
+  return {};
 }
 
 

--- a/libpolys/coeffs/flintcf_Zn.cc
+++ b/libpolys/coeffs/flintcf_Zn.cc
@@ -344,6 +344,7 @@ static number ExtGcd(number a, number b, number *s, number *t,const coeffs r)
 static number Lcm(number a, number b, const coeffs r)
 {
   WerrorS("not yet: Lcm");
+  return NULL;
 }
 static void Delete(number * a, const coeffs r)
 {
@@ -388,10 +389,12 @@ static number Init_bigint(number i, const coeffs dummy, const coeffs dst)
 static number Farey(number p, number n, const coeffs)
 {
   WerrorS("not yet: Farey");
+  return NULL;
 }
 static number ChineseRemainder(number *x, number *q,int rl, BOOLEAN sym,CFArray &inv_cache,const coeffs)
 {
   WerrorS("not yet: ChineseRemainder");
+  return NULL;
 }
 static int ParDeg(number x,const coeffs r)
 {
@@ -408,10 +411,13 @@ static number Parameter(const int i, const coeffs r)
 // cfClearDenominators
 static number ConvFactoryNSingN( const CanonicalForm n, const coeffs r)
 {
+  WerrorS("not yet: ConvFactoryNSingN");
+  return NULL;
 }
 static CanonicalForm ConvSingNFactoryN( number n, BOOLEAN setChar, const coeffs r )
 {
   WerrorS("not yet: ConvSingNFactoryN");
+  return NULL;
 }
 static char * CoeffName(const coeffs r)
 {


### PR DESCRIPTION
Not doing so is undefined behavior.

This issue was detected while building Singular for openSUSE using OBS, where the default compile flags include `-Werror=return-type`.