### PR TITLE
Fix arr.lib: Comparison A==A does not work for arr type

### DIFF
--- a/Singular/LIB/arr.lib
+++ b/Singular/LIB/arr.lib
@@ -350,7 +350,7 @@ EXAMPLE:    example arrDelete; shows an example"
         if(u[v[k]] != 0){ u[v[k]] = 0; i++; }   // i = #elts that need to be deleted
     }
 
-    if( i == n){return (emptyArr); }
+    if( i == n){arr emptyArr; return (emptyArr); }
 
 // create intvec of the remaining indices
     v = 1..(n-i); i=1;


### PR DESCRIPTION
____
ring r;
arr A=x;
A==A;
___
ging nicht mit 
___
 ? `_` is undefined
   ? error occurred in or before arr.lib::arrAdd line 203: `parameter list #; `
   ? leaving arr.lib::arrAdd (0)
   ? assign arr(540) = $INVALID$(0)
 error at token `;`
   ? leaving arr.lib::arrMinus (403)
   ? leaving arr.lib::arrLEQ (436)
   ? leaving arr.lib::arrEQ (474)
___
da emtyArr nirgendswo definiert war.