### PR TITLE
correct spelling error

### DIFF
--- a/libpolys/polys/flintconv.cc
+++ b/libpolys/polys/flintconv.cc
@@ -441,7 +441,7 @@ matrix singflint_rref(matrix  m, const ring R)
     fq_nmod_ctx_clear(ctx);
     fmpz_clear(p);
     #endif
-    WerrorS("not implmented for these coefficients");
+    WerrorS("not implemented for these coefficients");
   }
   return M;
 }


### PR DESCRIPTION
Description: source typo
 Correct spelling errors as reported by lintian in some binaries;
 meant to silence lintian and eventually to be submitted to the
 upstream maintainer.
Origin: debian
Comment: spelling-error-in-binary
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2021-12-17