### PR TITLE
Make the location of html files configurable

### DIFF
--- a/m4/options.m4
+++ b/m4/options.m4
@@ -172,9 +172,15 @@ AC_DEFUN([SING_USE_RESOURCES],
   AC_SUBST(RESOURCES_INCLUDES)
   AC_SUBST(RESOURCES_LIBS)
 
+# If htmldir is the default value, make sure it is passed to resources' configure so that a correct default value is used.
+# if htmldir is set when calling configure, its value is passed by AC_CONFIG_SUBDIRS to resources' configure without manual intervention.
+  if test "x$htmldir" = "x\${docdir}"; then 
+    DEFAULT_HTMLDIR="--htmldir=$datarootdir/doc/singular"
+  fi
+
   ENABLE_ARG="--with-Singular RESOURCES_LIBS='$RESOURCES_LIBS' RESOURCES_INCLUDES='$RESOURCES_INCLUDES'"
 
-  ac_configure_args="$ac_configure_args $ENABLE_ARG"
+  ac_configure_args="$ac_configure_args $DEFAULT_HTMLDIR $ENABLE_ARG"
 
   PKG_REQUIRE="$PKG_REQUIRE singular_resources"
   AC_SUBST(PKG_REQUIRE)

--- a/m4/options.m4
+++ b/m4/options.m4
@@ -172,8 +172,6 @@ AC_DEFUN([SING_USE_RESOURCES],
   AC_SUBST(RESOURCES_INCLUDES)
   AC_SUBST(RESOURCES_LIBS)
 
-# If htmldir is the default value, make sure it is passed to resources' configure so that a correct default value is used.
-# if htmldir is set when calling configure, its value is passed by AC_CONFIG_SUBDIRS to resources' configure without manual intervention.
   if test "x$htmldir" = "x\${docdir}"; then 
     DEFAULT_HTMLDIR="--htmldir=$datarootdir/doc/singular"
   fi

--- a/m4/options.m4
+++ b/m4/options.m4
@@ -173,7 +173,7 @@ AC_DEFUN([SING_USE_RESOURCES],
   AC_SUBST(RESOURCES_LIBS)
 
   if test "x$htmldir" = "x\${docdir}"; then 
-    DEFAULT_HTMLDIR="--htmldir=$datarootdir/doc/singular"
+    DEFAULT_HTMLDIR="--htmldir=$datarootdir/singular/html"
   fi
 
   ENABLE_ARG="--with-Singular RESOURCES_LIBS='$RESOURCES_LIBS' RESOURCES_INCLUDES='$RESOURCES_INCLUDES'"

--- a/resources/configure.ac
+++ b/resources/configure.ac
@@ -72,5 +72,10 @@ AX_RECURSIVE_EVAL([[$]datadir], [config_datadir])
 AX_NORMALIZE_PATH([config_datadir],['/'])
 AC_DEFINE_UNQUOTED([DATA_DIR],"$config_datadir",[datadir])
 
+AX_RECURSIVE_EVAL([[$]htmldir], [config_htmldir])
+AX_NORMALIZE_PATH([config_htmldir],['/'])
+AX_COMPUTE_RELATIVE_PATHS([config_datadir:config_htmldir:data_to_html])
+AC_DEFINE_UNQUOTED([DATA_TO_HTML_DIR],"%D/$data_to_html",[htmldir])
+
 AC_CONFIG_FILES([singular_resources.pc Makefile])
 AC_OUTPUT

--- a/resources/feResource.cc
+++ b/resources/feResource.cc
@@ -78,7 +78,7 @@ VAR feResourceConfig_s feResourceConfigs[] =
   {"DefaultDir",'d',    feResDir,   "SINGULAR_DEFAULT_DIR",  SINGULAR_DEFAULT_DIR,  (char *)""},
   {"InfoFile",  'i',    feResFile,  "SINGULAR_INFO_FILE",   "%D/info/singular.info", (char *)""},
   {"IdxFile",   'x',    feResFile,  "SINGULAR_IDX_FILE",    "%D/singular/singular.idx",  (char *)""},
-  {"HtmlDir",   'h',    feResDir,   "SINGULAR_HTML_DIR",    "%D/singular/html",              (char *)""},
+  {"HtmlDir",   'h',    feResDir,   "SINGULAR_HTML_DIR",    DATA_TO_HTML_DIR,       (char *)""},
   {"ManualUrl", 'u',    feResUrl,   "SINGULAR_URL",         "https://www.singular.uni-kl.de/Manual/",    (char *)""},
   {"ExDir",     'm',    feResDir,   "SINGULAR_EXAMPLES_DIR","%r/examples",          (char *)""},
   {"Path",      'p',    feResPath,  NULL,                   "%b;%P;$PATH",             (char *)""},


### PR DESCRIPTION
Since around singular 4.0.x I have been using this patch in Gentoo in some form. The rationale is that linux distribution typically have policy for where the html documentation should be installed. Of course, simply moving the html files in the wanted location will break singular's ability to consult it because the change has to be mirrored in `feResource.cc`. So, this branch create the necessary `HTML_DIR` variable in the appropriate `configure.ac` file and make use of it in `feResource.cc`.

When no `--htmldir` option is passed to configure the previously expected singular default is used. So, in this branch, the behavior is only changed when `--htmldir` is not empty.

Some of the other values in `feResource.cc` may gain to be made more configurable in that way.