### PR TITLE
Singular/Makefile.am: use FACTORY_LIBS when linking Singular.

### DIFF
--- a/Singular/Makefile.am
+++ b/Singular/Makefile.am
@@ -152,7 +152,7 @@ bin_PROGRAMS = Singular ESingular TSingular $(optional_Singular_programs)
 
 Singular_SOURCES = tesths.cc utils.cc  utils.h
 
-Singular_LDADD = libSingular.la ${OMALLOC_LIBS} ${BUILTIN_FLAGS}
+Singular_LDADD = libSingular.la ${OMALLOC_LIBS} ${BUILTIN_FLAGS} $(FACTORY_LIBS)
 
 Singular_LDFLAGS = ${AM_LDFLAGS} ${BUILTIN_FLAGS}
 


### PR DESCRIPTION
When building with --enable-factory, Singular should be linked against
FACTORY_LIBS. GNU libtool manages to ignore this somehow, but when
building with slibtool, one sees e.g.:

  rlibtool: link: x86_64-pc-linux-gnu-g++ ... -o .libs/Singular
  mold: error: undefined symbol: tesths.o: feArgv0
  mold: error: undefined symbol: tesths.o: fe_optarg
  mold: error: undefined symbol: tesths.o: fe_optarg
  ...

This commit adds FACTORY_LIBS to Singular_LDADD within Makefile.am to
fix the build with those stricter tools.