### PR TITLE
build: repair -DMAKE_DISTRIBUTION build

### DIFF
--- a/libpolys/reporter/dError.cc
+++ b/libpolys/reporter/dError.cc
@@ -123,7 +123,7 @@ int dReportError(const char* fmt, ...)
   dErrorBreak();
 #else
   fprintf(stderr, "\n// !!! YOU HAVE FOUND A BUG IN SINGULAR.");
-  fprintf(stderr, "// !!! Please, email the input\n// and the following error message to singular@mathematik.uni-kl.de")
+  fprintf(stderr, "// !!! Please, email the input\n// and the following error message to singular@mathematik.uni-kl.de");
   vfprintf(stderr, fmt, ap);
 #endif
   return 0;


### PR DESCRIPTION
```
  CXX      dError.lo
dError.cc: In function 'int dReportError(const char*, ...)':
dError.cc:126:121: error: expected ';' before 'vfprintf'
  126 |   fprintf(stderr, "// !!! Please, email the input\n// and the following error message to singular@mathematik.uni-kl.de")
      |                                                                                                                         ^
      |                                                                                                                         ;
  127 |   vfprintf(stderr, fmt, ap);
      |   ~~~~~~~~
```