### PR TITLE
src: remove __DATE__/__TIME__

### DIFF
--- a/Singular/emacs.cc
+++ b/Singular/emacs.cc
@@ -86,7 +86,7 @@ void fePrintReportBug(char* msg, char* file, int line)
 "Please, email the following output to singular@mathematik.uni-kl.de\n"
 "Bug occurred at %s:%d\n"
 "Message: %s\n"
-"Version: " S_UNAME VERSION __DATE__ __TIME__,
+"Version: " S_UNAME VERSION,
         file, line, msg);
 
 }

--- a/Singular/misc_ip.cc
+++ b/Singular/misc_ip.cc
@@ -764,7 +764,7 @@ extern "C"
 #endif
 
 #ifndef MAKE_DISTRIBUTION
-const char *singular_date=__DATE__ " " __TIME__;
+const char *singular_date = "";
 #endif
 
 char * versionString(/*const bool bShowDetails = false*/ )


### PR DESCRIPTION
	singular-libSingular-3_1_90.x86_64: W: file-contains-date-and-time
	/usr/lib64/singular/libSingular.so
	Your file uses __DATE__ and __TIME__ this causes the package
	to rebuild when not needed.

In the Open Build Service, Singular is rebuilt when a parent package
is rebuilt. However, if the resulting "new" Singular package has the
same checksum, the result is discarded, so that end-users do _not_
needlessy get idempotent updates offered through their package
manager.

__DATE__ or __TIME__ voids the effectiveness of discarding the result,
as the checksum is always different.