### PR TITLE
fix some typos in kernel/spektrum

### DIFF
--- a/kernel/spectrum/kmatrix.h
+++ b/kernel/spectrum/kmatrix.h
@@ -29,7 +29,7 @@
 //  The complexity function should return a measure indicating
 //  how complicated this number is in terms of memory usage
 //  and arithmetic operations. For a rational p/q, one could
-//  return max(|p|,|q|). This fuction is used for pivoting.
+//  return max(|p|,|q|). This function is used for pivoting.
 //
 //  The gcd of two numbers a,b should be a number g such that
 //  the complexities of a/g and b/g are less or equal than those
@@ -43,7 +43,7 @@ template<class K> class KMatrix
 
 private:
 
-    K    *a;                                // the entries ot the matrix
+    K    *a;                                // the entries of the matrix
     int rows;                               // number of rows
     int cols;                               // number of columns
 

--- a/kernel/spectrum/npolygon.cc
+++ b/kernel/spectrum/npolygon.cc
@@ -290,7 +290,7 @@ int linearForm::positive( void )
 
 
 // ----------------------------------------------------------------------------
-//  Allocate memory for a newton polygon of  k  linear forms
+//  Allocate memory for a Newton polygon of  k  linear forms
 // ----------------------------------------------------------------------------
 
 void    newtonPolygon::copy_new( int k )
@@ -644,7 +644,7 @@ Rational  newtonPolygon::weight_shift1( poly m, const ring r ) const
 
 /*
 // ----------------------------------------------------------------------------
-//  Chcek if the polynomial belonging to the Newton polygon
+//  Check if the polynomial belonging to the Newton polygon
 //  is semiquasihomogeneous (sqh)
 // ----------------------------------------------------------------------------
 

--- a/kernel/spectrum/semic.cc
+++ b/kernel/spectrum/semic.cc
@@ -356,7 +356,7 @@ int     spectrum::next_interval( Rational *alpha1,Rational *alpha2 )
 }
 
 // ----------------------------------------------------------------------------
-//  compute the numver of spectrum numbers in the inverval  [*alpha1,*alpha2]
+//  compute the number of spectrum numbers in the interval  [*alpha1,*alpha2]
 // ----------------------------------------------------------------------------
 
 int     spectrum::numbers_in_interval( Rational &alpha1,

--- a/kernel/spectrum/splist.cc
+++ b/kernel/spectrum/splist.cc
@@ -47,7 +47,7 @@ void    spectrumPolyNode::copy_zero( void )
 }
 
 // ----------------------------------------------------------------------------
-//  Inizialize a  spectrumPolyNode  shallow from data
+//  Initialize a  spectrumPolyNode  shallow from data
 // ----------------------------------------------------------------------------
 
 void    spectrumPolyNode::copy_shallow(
@@ -61,7 +61,7 @@ void    spectrumPolyNode::copy_shallow(
 }
 
 // ----------------------------------------------------------------------------
-//  Inizialize a  spectrumPolyNode  shallow from another  spectrumPolyNode
+//  Initialize a  spectrumPolyNode  shallow from another  spectrumPolyNode
 // ----------------------------------------------------------------------------
 
 void    spectrumPolyNode::copy_shallow( spectrumPolyNode &node )
@@ -119,7 +119,7 @@ void    spectrumPolyList::copy_zero( void )
 }
 
 // ----------------------------------------------------------------------------
-//  Inizialize a  spectrumPolyList  shallow from data
+//  Initialize a  spectrumPolyList  shallow from data
 // ----------------------------------------------------------------------------
 
 void    spectrumPolyList::copy_shallow(
@@ -131,7 +131,7 @@ void    spectrumPolyList::copy_shallow(
 }
 
 // ----------------------------------------------------------------------------
-//  Inizialize a  spectrumPolyList  shallow from another  spectrumPolyList
+//  Initialize a  spectrumPolyList  shallow from another  spectrumPolyList
 // ----------------------------------------------------------------------------
 
 void    spectrumPolyList::copy_shallow( spectrumPolyList &splist )
@@ -158,7 +158,7 @@ spectrumPolyList::spectrumPolyList( newtonPolygon *npolygon )
 }
 
 // ----------------------------------------------------------------------------
-//  Destuctor for  spectrumPolyList
+//  Destructor for  spectrumPolyList
 // ----------------------------------------------------------------------------
 
 spectrumPolyList::~spectrumPolyList( )
@@ -178,7 +178,7 @@ spectrumPolyList::~spectrumPolyList( )
 // ----------------------------------------------------------------------------
 //  Insert a new node into a  spectrumPolyList  at position k
 //      If the list is sorted, then
-//      the new node ist inserted such that the list remains sorted.
+//      the new node is inserted such that the list remains sorted.
 // ----------------------------------------------------------------------------
 
 void    spectrumPolyList::insert_node( poly m,poly f, const ring R )

--- a/kernel/spectrum/test.cc
+++ b/kernel/spectrum/test.cc
@@ -309,7 +309,7 @@ void TestSimpleRingArithmetcs()
   // create the polynomial 1
   poly p1=pISet(1);
 
-  // create tthe polynomial 2*x^3*z^2
+  // create the polynomial 2*x^3*z^2
   poly p2=p_ISet(2,R);
   pSetExp(p2,1,3);
   pSetExp(p2,3,2);
@@ -345,7 +345,7 @@ int main( int, char *argv[] )
 
   feInitResources(argv[0]);
 
-  StringSetS("ressources in use (as reported by feStringAppendResources(0):\n");
+  StringSetS("resources in use (as reported by feStringAppendResources(0):\n");
   feStringAppendResources(0);
 
   PrintLn();


### PR DESCRIPTION
just a few simple typos, found using codespell