### PR TITLE
Edge case of total localization in olga.lib

### DIFF
--- a/Singular/LIB/olga.lib
+++ b/Singular/LIB/olga.lib
@@ -403,11 +403,16 @@ EXAMPLE: example isInS; shows examples"
         if (!override) {
             locData = normalizeRational(locData);
         }
-        ideal I = p;
-        intvec modLocData = intvecComplement(locData, 1..nvars(basering));
-        I = eliminateNC(I, modLocData);
-        if (size(I)) {
-            return(1);
+        int n = nvars(basering);
+        if (size(locData) < n) { // there are variables to eliminate
+            ideal I = p;
+            intvec modLocData = intvecComplement(locData, 1..nvars(basering));
+            I = eliminateNC(I, modLocData);
+            if (size(I)) {
+                return(1);
+            }
+        } else {
+            return(p != 0);
         }
     }
     return(0);
@@ -1469,6 +1474,13 @@ static proc testIsInS()
     }
     if (isInS(x*y, 2, v)) {
         ERROR("Weyl rational isInS negative failed");
+    }
+    intvec w = 4,2,3,4,1;
+    if (!isInS(x*y*Dx*Dy,2,w)) {
+        ERROR("Weyl total rational isInS positive failed");
+    }
+    if (isInS(0, 2, w)) {
+        ERROR("Weyl total rational isInS negative failed");
     }
     print("    isInS OK");
 }


### PR DESCRIPTION
In the situation where `locData` is `1,...,nvars(basering)`, no elimination is needed, since then one only needs to check whether the element `p` in question is zero or not (this corresponds to localizing a ring $A$ at $A\setminus\{0\}$, so everything but $0$ is a valid denominator).

The previous version tried to find the complement of `locData` in `1,...,nvars(basering)` and would pass an "empty" `intvec` to `eliminateNC`, which it does not like very much. At some point in the past during the development of this library I fixed this in a similar fashion in the procedure `ore`, but obviously I forgot to do the same at `isInS`.