### PR TITLE
fix broken module machinery in libpolys

### DIFF
--- a/libpolys/configure.ac
+++ b/libpolys/configure.ac
@@ -85,10 +85,8 @@ AC_CANONICAL_HOST
 
 case $host_os in
   *cygwin* ) AX_APPEND_LINK_FLAGS([-Wl,-Bdynamic]);;
-  *) AX_APPEND_LINK_FLAGS([-shared -dynamic -export-dynamic -avoid-version -flat_namespace],[P_PROCS_MODULE_LDFLAGS]);;
+  *) ;;
 esac
-
-AC_SUBST(P_PROCS_MODULE_LDFLAGS)
 
 dnl INCLUDES=""
 dnl dnl OS specific flags and options (does work without the following:)

--- a/libpolys/polys/Makefile.am
+++ b/libpolys/polys/Makefile.am
@@ -18,9 +18,11 @@ endif
 if ENABLE_P_PROCS_DYNAMIC
   USE_P_PROCS_DYNAMIC_CC = templates/p_Procs_Dynamic.cc
   P_PROCS_CPPFLAGS_COMMON = ${AM_CPPFLAGS} -DDYNAMIC_VERSION
+  P_PROCS_MODULE_LDFLAGS = -module -export-dynamic -avoid-version
 else
   USE_P_PROCS_DYNAMIC_CC =
   P_PROCS_CPPFLAGS_COMMON = ${AM_CPPFLAGS}
+  P_PROCS_MODULE_LDFLAGS = -module
 endif
 
 
@@ -69,10 +71,10 @@ p_Procs_FieldIndep_la_CPPFLAGS = -Dp_Procs_FieldIndep ${P_PROCS_CPPFLAGS_COMMON}
 p_Procs_FieldQ_la_CPPFLAGS = -Dp_Procs_FieldQ ${P_PROCS_CPPFLAGS_COMMON}
 p_Procs_FieldZp_la_CPPFLAGS = -Dp_Procs_FieldZp ${P_PROCS_CPPFLAGS_COMMON}
 
-p_Procs_FieldGeneral_la_LDFLAGS = -module ${P_PROCS_MODULE_LDFLAGS}
-p_Procs_FieldIndep_la_LDFLAGS = -module ${P_PROCS_MODULE_LDFLAGS}
-p_Procs_FieldQ_la_LDFLAGS = -module ${P_PROCS_MODULE_LDFLAGS}
-p_Procs_FieldZp_la_LDFLAGS = -module ${P_PROCS_MODULE_LDFLAGS}
+p_Procs_FieldGeneral_la_LDFLAGS = ${P_PROCS_MODULE_LDFLAGS}
+p_Procs_FieldIndep_la_LDFLAGS = ${P_PROCS_MODULE_LDFLAGS}
+p_Procs_FieldQ_la_LDFLAGS = ${P_PROCS_MODULE_LDFLAGS}
+p_Procs_FieldZp_la_LDFLAGS = ${P_PROCS_MODULE_LDFLAGS}
 
 P_PROCS = templates/p_Procs_Lib.cc
 


### PR DESCRIPTION
The libpolys machinery to build modules appears broken. This is because a  mixture of linker options and libtools options is passed to a m4-macro (AX_APPEND_LINK_FLAGS) that filters only linker options. This patch attempts to fix this issue by mimicking the machinery currently used to build modules in the Singular folder.