### PR TITLE
Add some missing includes

### DIFF
--- a/factory/FLINTconvert.h
+++ b/factory/FLINTconvert.h
@@ -45,6 +45,7 @@ extern "C"
 #endif
 #if ( __FLINT_RELEASE >= 20700)
 #include <flint/fq_nmod_mpoly_factor.h>
+#include <flint/fmpz_mod.h>
 #endif
 #endif
 

--- a/factory/cfModGcd.cc
+++ b/factory/cfModGcd.cc
@@ -22,6 +22,7 @@
 
 #include "config.h"
 
+#include <math.h>
 
 #include "cf_assert.h"
 #include "debug.h"

--- a/factory/cfModResultant.cc
+++ b/factory/cfModResultant.cc
@@ -13,6 +13,7 @@
 
 #include "config.h"
 
+#include <math.h>
 
 #include "cf_assert.h"
 #include "timing.h"

--- a/factory/facFqBivar.cc
+++ b/factory/facFqBivar.cc
@@ -19,6 +19,7 @@
 
 #include "config.h"
 
+#include <math.h>
 
 #include "cf_assert.h"
 #include "cf_util.h"

--- a/factory/facFqFactorize.cc
+++ b/factory/facFqFactorize.cc
@@ -18,6 +18,7 @@
 
 #include "config.h"
 
+#include <math.h>
 
 #include "cf_assert.h"
 #include "debug.h"

--- a/factory/facMul.cc
+++ b/factory/facMul.cc
@@ -22,6 +22,7 @@
 
 #include "config.h"
 
+#include <math.h>
 
 #include "canonicalform.h"
 #include "facMul.h"


### PR DESCRIPTION
These are needed when building with flint 3.0 and without ntl.