### PR TITLE
fix some file encodings (to utf8) and some typos in doc/ folder

### DIFF
--- a/doc/Makefile-docbuild.in
+++ b/doc/Makefile-docbuild.in
@@ -72,7 +72,7 @@ HTML_TUTOR_PREFIX  = tut
 HTML_MANUAL_TOP    = index.htm
 HTML_TUTOR_TOP     = tutor.htm
 ##
-## End configuration dependend stuff
+## End configuration dependent stuff
 #################################################################
 
 ###########################################################

--- a/doc/NEWS.texi
+++ b/doc/NEWS.texi
@@ -42,7 +42,7 @@ Changes in the kernel/build system:
       and zero dimensional ideal over @code{QQ}
 @item new algorithm for lift function (@nref{lift})
 @item mstd for local rings (@nref{mstd})
-@item use the new Hilbert function algorith for @nref{hilb}. (Different output format)
+@item use the new Hilbert function algorithm for @nref{hilb}. (Different output format)
 @item overflow in @code{hilb} is an error (on request of a single user)
 @end itemize
 

--- a/doc/STYLEGUIDE
+++ b/doc/STYLEGUIDE
@@ -49,7 +49,7 @@
 + Email Adressen in @email{...} notieren, URL's in @uref{...}
 
 + Multicolumn tables: Rows of multicolumn tables need to go in one
-  line, otherwise texi2html chockes. Space beween rows with "empty"
+  line, otherwise texi2html chockes. Space between rows with "empty"
   rows (c.f. texi2html), i.e., with @item @tab @tab ....
 
 
@@ -219,20 +219,20 @@ i;  // mit Leerzeichen beginnen.
 
 + mit der neuen Version von doc2tex kann (soll) man Listen von
   Cross-Referenzen wie folgt schreiben:
-    @c ref
-    See
-    @ref{std};
-    @ref{stdfac};
-    @ref{stdhilbert}.
-    @c ref
-  Daraus wird dann automatisch ein Menue fuer die info-Files erzeugt.
-  (Man kann sich also das "@menu * std:: ...  @end menu" sparen.)
-  Bitte pro Zeile nur *eine* Referenz notieren und das `See'
-  in eine eigene Zeile packen.  Das macht die Sache
-  uebersichtlicher.  Ausserdem kann man die Referenzen dann
-  leichter im Editor handhaben (loeschen, alphabetisch
-  sortieren).
-  Die Referenzen bitte alphabetisch sortieren und mit einem Semikolon
+Â Â Â  @c ref
+Â Â Â  See
+Â Â Â  @ref{std};
+Â Â Â  @ref{stdfac};
+Â Â Â  @ref{stdhilbert}.
+Â Â Â  @c ref
+Â  Daraus wird dann automatisch ein Menue fuer die info-Files erzeugt.
+Â  (Man kann sich also das "@menu * std:: ...Â  @end menu" sparen.)
+Â  Bitte pro Zeile nur *eine* Referenz notieren und das `See'
+Â  in eine eigene Zeile packen.Â  Das macht die Sache
+Â  uebersichtlicher.Â  Ausserdem kann man die Referenzen dann
+Â  leichter im Editor handhaben (loeschen, alphabetisch
+Â  sortieren).
+Â  Die Referenzen bitte alphabetisch sortieren und mit einem Semikolon
   trennen.
 
 * Index, Anchors*

--- a/doc/build_standards
+++ b/doc/build_standards
@@ -1,4 +1,4 @@
-Main goal is to standarize the build process according to the GNU standards below:
+Main goal is to standardize the build process according to the GNU standards below:
 
 1. compilation should work only using
 

--- a/doc/doc2idx.pl
+++ b/doc/doc2idx.pl
@@ -9,7 +9,7 @@
 #  $indexentry\t$nodename\t$url\t$chksum
 #
 #  where $indexentry: entries of index (all lower case)
-#        $nodename  : name of node where index entry occured
+#        $nodename  : name of node where index entry occurred
 #        $url       : url of node
 #        $chksum    : checksum of help text, if library proc node
 # lines are sorted alphabetically w.r.t. $indexentry

--- a/doc/doc2tex.pl
+++ b/doc/doc2tex.pl
@@ -377,7 +377,7 @@ sub HandleExample
       if (system("echo '\$' | $Singular $Singular_opts > $res_file"))
       {
 	$Singular .= '.exe' if ($Win32 && $Singular !~ /\.exe$/);
-	Error("Can´t run '$Singular $Singular_opts': $@")
+	Error("CanÂ´t run '$Singular $Singular_opts': $@")
 	  if (system("echo '\$' | $Singular $Singular_opts > $res_file"));
       }
       $Singular_OK = 1

--- a/doc/general.doc
+++ b/doc/general.doc
@@ -414,7 +414,7 @@ Library, Command Line Editing, readline, The GNU Readline Library
 Manual}, for more information. If a shared version of this library can
 be found on your machine, then additional command-line editing
 features like  history completion are available.
-In particuliar, if @sc{Singular} is able to load that library
+In particular, if @sc{Singular} is able to load that library
 the input history is stored across sessions using the file given in
 the environment variable @code{SINGULARHIST}.
 If @code{SINGULARHIST} is not set @code{.singularhistory} is used.

--- a/doc/letterplace.doc
+++ b/doc/letterplace.doc
@@ -1394,7 +1394,7 @@ We say that a subset @math{G} of @math{I} is a @strong{(two-sided) Groebner basi
 @end ifinfo
 
 Suppose, that the weights of the ring variables are strictly positive.
-We can interprete these weights as defining a non-standard grading on the ring.
+We can interpret these weights as defining a non-standard grading on the ring.
 If the set of input polynomials is weighted homogeneous with respect to the given
 weights of the ring variables, then computing up to a weighted degree (and thus, also length) bound @math{d}
 results in the @strong{truncated Groebner basis} @math{G(d)}. In other words, by trimming elements

--- a/doc/manual-titlepage.tex
+++ b/doc/manual-titlepage.tex
@@ -11,7 +11,7 @@
 %\usepackage{float}
 %\usepackage[isolatin]{inputenc}
 
-% Abs�tze: kein Einr�cken, vertikaler Abstand
+% Absätze: kein Einrücken, vertikaler Abstand
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{5pt plus 2pt minus 1pt}
 \sloppy
@@ -41,15 +41,15 @@
 
 \vspace{5ex}
 
-\Large{By G.-M.~Greuel, G.~Pfister, and H.~Sch\"onemann}
+\Large{By G.-M.~Greuel, G.~Pfister, and H.~Schönemann}
 \end{center}
 
 \begin{center}
   \large{With contributions by} \\
 \large{O.~Bachmann, T.~Siebert, T.~Wichmann, W.~Pohl,
-A.~Fr\"ubis-Kr\"uger, W.~Decker, S.~Endra\ss, C.~ Gorzel, H.~ Grassmann,
-A.~Heydtmann, D.~Hillebrand, C.~Jung, U.~Klein, K.~Kr\"uger, M.~Lamm,
-B.~Martin, M.~ Messollen, W.~ Neumann, T.~N\"ussler, J.~Schmidt, M.~Schulze, R.
+A.~Frübis-Krüger, W.~Decker, S.~Endra\ss, C.~ Gorzel, H.~ Grassmann,
+A.~Heydtmann, D.~Hillebrand, C.~Jung, U.~Klein, K.~Krüger, M.~Lamm,
+B.~Martin, M.~ Messollen, W.~ Neumann, T.~Nüssler, J.~Schmidt, M.~Schulze, R.
 Stobbe, M.~Wenk.}
 \end{center}
 
@@ -60,8 +60,8 @@ Stobbe, M.~Wenk.}
     URL: \verb?http://www.mathematik.uni-kl.de/~zca/Singular? \\
     email: \verb?singular@mathematik.uni-kl.de?\\
     Fachbereich Mathematik \\
-    Zentrum f\"ur Computeralgebra \\
-    Universit\"at Kaiserslautern \\
+    Zentrum für Computeralgebra \\
+    Universität Kaiserslautern \\
     D-67653 Kaiserslautern \\
     Germany}
 \end{center}

--- a/doc/plural.doc
+++ b/doc/plural.doc
@@ -797,7 +797,7 @@ a type cast to module
 
 @table @asis
 @item @code{+}
-addition (concatenation of the generators and simplification) Note that ''-'' implicitely converts a module into a matrix; see
+addition (concatenation of the generators and simplification) Note that ''-'' implicitly converts a module into a matrix; see
 below example.
 
 @item @code{*}

--- a/doc/reference.doc
+++ b/doc/reference.doc
@@ -7657,7 +7657,7 @@ abort the Singular process after computing for that many seconds (system+user cp
 absolute factorization of the polynomial
 (from a polynomial ring over a transzedental extension)
 Returns a list of the ideal of the factors, intvec of multiplicities,
-ideal of minimal polynomials and the bumber of factors.
+ideal of minimal polynomials and the number of factors.
 @c ..........................
 @item @code{system("blackbox")}
 @cindex system, blackbox

--- a/doc/singular.dic
+++ b/doc/singular.dic
@@ -339,7 +339,7 @@ Grassmann
 greuel
 groebner
 groupid
-Gröbner
+GrÃ¶bner
 GTZ
 GTZmod
 GTZopt
@@ -502,7 +502,7 @@ koszul
 Krick
 krueger
 Krull
-Krüger
+KrÃ¼ger
 KSpencerKernel
 Kxt
 laguerre
@@ -860,7 +860,7 @@ rs
 rsh
 rtimer
 Ruediger
-Rüdiger
+RÃ¼diger
 rvalue
 rvar
 SAGBI
@@ -873,7 +873,7 @@ Scala
 Scala's
 Schimoyama
 Schoenemann
-Schönemann
+SchÃ¶nemann
 Schreyer
 Schreyer's
 Schulze

--- a/doc/singular.doc
+++ b/doc/singular.doc
@@ -387,7 +387,7 @@ LIB "all.lib";
 * assprimeszerodim_lib:: associated primes of a zero-dimensional ideal
 * cisimplicial_lib:: is the toric ideal of a simplicial toric variety a complete intersection?
 * curveInv_lib:: invariants of curves
-* decomp_lib:: Funtional decomposition os polynomials
+* decomp_lib:: Functional decomposition of polynomials
 * elim_lib:: procedures for elimination, saturation and blowing up
 * ellipticcovers_lib::  Gromov Witten numbers of elliptic curves
 * ffmodstd_lib::  Groebner bases in polynomial rings over rational function fields

--- a/doc/tutor-titlepage.tex
+++ b/doc/tutor-titlepage.tex
@@ -11,7 +11,7 @@
 %\usepackage{float}
 %\usepackage[isolatin]{inputenc}
 
-% Abs�tze: kein Einr�cken, vertikaler Abstand
+% Absätze: kein Einrücken, vertikaler Abstand
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{5pt plus 2pt minus 1pt}
 \sloppy
@@ -42,14 +42,14 @@
 
 \vspace{5ex}
 
-\Large{By G.-M.~Greuel, G.~Pfister, and H.~Sch\"onemann}
+\Large{By G.-M.~Greuel, G.~Pfister, and H.~Schönemann}
 \end{center}
 
 \begin{center}
   \large{With contributions by} \\
 \large{O.~Bachmann, W.~Decker, C.~Gorzel,
-  H.~Grassmann, A.~Heydtmann, K.~Kr\"uger, M.~Lamm, B.~Martin,
-  M.~Messollen, W.~Neumann, T.~N\"ussler, W.~Pohl, T.~Siebert,
+  H.~Grassmann, A.~Heydtmann, K.~Krüger, M.~Lamm, B.~Martin,
+  M.~Messollen, W.~Neumann, T.~Nüssler, W.~Pohl, T.~Siebert,
   R.~Stobbe, and T.~Wichmann.}
 \end{center}
 
@@ -60,8 +60,8 @@
     URL: \verb?http://www.mathematik.uni-kl.de/~zca/Singular? \\
     email: \verb?singular@mathematik.uni-kl.de?\\
     Fachbereich Mathematik \\
-    Zentrum f\"ur Computeralgebra \\
-    Universit\"at Kaiserslautern \\
+    Zentrum für Computeralgebra \\
+    Universität Kaiserslautern \\
     D-67653 Kaiserslautern \\
     Germany}
 \end{center}

--- a/doc/types.doc
+++ b/doc/types.doc
@@ -4765,7 +4765,7 @@ For kernel_command having a variable number of arguments (internal @code{CMD_M})
 use 4 independent of the number of really supplied arguments.
 
 List of available kernel commands and the required number_of_args,
-some accept several variants and appear therefor at several places:
+some accept several variants and appear therefore at several places:
 @itemize
 @item inplace binary operands: @code{+,-,*,/,div,%,&,|, [}, number_of_args:2
 @item unary functions:


### PR DESCRIPTION
I have changed the encoding of a few files in `doc/` to standard utf8.

In some tex files, I have converted tex-style german letter such as `\"u` to unicode such as `ü`. Hopefully doc should compile, but maybe one needs to say latex explicitly that utf8 is used. I am not sure.

Also fixed a few typos.