### PR TITLE
Fix a sequence point error in gfanlib

### DIFF
--- a/gfanlib/gfanlib_tropicalhomotopy.h
+++ b/gfanlib/gfanlib_tropicalhomotopy.h
@@ -454,7 +454,7 @@ template<class mvtyp, class mvtypDouble, class mvtypDivisor>
                         //chioices are "relative" so no update is needed.
 
                         choices=parent.choices;
-                        int numberToDrop=(subconfigurationIndex!=0) ? numberToDrop=k+1 : 0;
+                        int numberToDrop=(subconfigurationIndex!=0) ? k+1 : 0;
 
                         choices[subconfigurationIndex-1].first-=numberToDrop;
                         choices[subconfigurationIndex-1].second-=numberToDrop;


### PR DESCRIPTION
Fixex this warning:
```
gfanlib_tropicalhomotopy.h:457:83: warning: operation on 'numberToDrop' may be undefined [-Wsequence-point]
  457 |                         int numberToDrop=(subconfigurationIndex!=0) ? numberToDrop=k+1 : 0;
      |                                                                       ~~~~~~~~~~~~^~~~
```
