### PR TITLE
Remove extra delete statement in gaussianElimFq

### DIFF
--- a/factory/cfModGcd.cc
+++ b/factory/cfModGcd.cc
@@ -1826,7 +1826,6 @@ gaussianElimFq (CFMatrix& M, CFArray& L, const Variable& alpha)
   #else
   factoryError("NTL/FLINT missing: gaussianElimFq");
   #endif
-  delete N;
 
   M= (*N) (1, M.rows(), 1, M.columns());
   L= CFArray (M.rows());


### PR DESCRIPTION
N is dereferenced 2 and 5 lines below this delete statement, and then the delete statement is repeated 7 lines below.  The first delete statement is clearly wrong.
