### PR TITLE
doc: Add missing `tag:normaliz`, fix quoting bug, update Sage CI (macOS arm64 testing)

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -137,15 +137,14 @@ jobs:
     needs: [dist, kanarienvogel]
 
   macos:
-    uses: sagemath/sage/.github/workflows/macos.yml@develop
+    # Use https://github.com/sagemath/sage/pull/37237
+    uses: mkoeppe/sage/.github/workflows/macos.yml@ci-macos-2024
+    #uses: sagemath/sage/.github/workflows/macos.yml@develop
     with:
-      osversion_xcodeversion_toxenv_tuples: >-
-        [["latest", "",           "homebrew-macos-usrlocal-minimal"],
-         ["latest", "",           "homebrew-macos-usrlocal-standard"],
-         ["13",     "xcode_15.0", "homebrew-macos-usrlocal-standard"]]
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular singular
       targets_optional: SAGE_CHECK=no SAGE_CHECK_pysingular=warn pysingular
       sage_repo:         sagemath/sage
-      sage_ref:          develop
+      sage_ref:          refs/pull/37237/head
+      #sage_ref:          develop
       upstream_artifact: upstream
     needs: [dist, kanarienvogel]

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -103,8 +103,10 @@ jobs:
       # https://github.com/sagemath/sage/tree/develop/build/pkgs
       extra_sage_packages: "info"
       # Sage distribution packages to build
-      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular singular
+      targets_pre: SAGE_CHECK=no singular-build-deps
+      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular V=1 singular
       targets_optional: SAGE_CHECK=no SAGE_CHECK_pysingular=warn pysingular
+      timeout: 3000
       # Standard setting: Test the current beta release of Sage:
       sage_repo: sagemath/sage
       sage_ref: develop
@@ -123,8 +125,10 @@ jobs:
       # https://github.com/sagemath/sage/tree/develop/build/pkgs
       extra_sage_packages: "info"
       # Sage distribution packages to build
-      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular singular
+      targets_pre: SAGE_CHECK=no singular-build-deps
+      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular V=1 singular
       targets_optional: SAGE_CHECK=no SAGE_CHECK_pysingular=warn pysingular
+      timeout: 3000
       # Standard setting: Test the current beta release of Sage:
       sage_repo: sagemath/sage
       sage_ref: develop
@@ -141,8 +145,10 @@ jobs:
     uses: mkoeppe/sage/.github/workflows/macos.yml@ci-macos-2024
     #uses: sagemath/sage/.github/workflows/macos.yml@develop
     with:
-      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular singular
+      targets_pre: SAGE_CHECK=no singular-build-deps
+      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular V=1 singular
       targets_optional: SAGE_CHECK=no SAGE_CHECK_pysingular=warn pysingular
+      timeout: 3000
       sage_repo:         sagemath/sage
       sage_ref:          refs/pull/37237/head
       #sage_ref:          develop

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -101,7 +101,7 @@ jobs:
         ["standard"]
       # Extra system packages to install. See available packages at
       # https://github.com/sagemath/sage/tree/develop/build/pkgs
-      extra_sage_packages: "info"
+      extra_sage_packages: "info ncurses readline"
       # Sage distribution packages to build
       targets_pre: SAGE_CHECK=no singular-build-deps
       targets: GITHUB_ACTIONS=1 SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular V=1 singular
@@ -123,7 +123,7 @@ jobs:
     with:
       # Extra system packages to install. See available packages at
       # https://github.com/sagemath/sage/tree/develop/build/pkgs
-      extra_sage_packages: "info"
+      extra_sage_packages: "info ncurses readline"
       # Sage distribution packages to build
       targets_pre: SAGE_CHECK=no singular-build-deps
       targets: GITHUB_ACTIONS=1 SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular V=1 singular

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -85,7 +85,7 @@ jobs:
           && mkdir -p upstream && cp build/pkgs/${{ env.SPKG }}/src/*.tar.gz upstream/${{ env.SPKG }}-git.tar.gz \
           && echo "sage-package create ${{ env.SPKG }} --version git --tarball ${{ env.SPKG }}-git.tar.gz --type=optional" > upstream/update-pkgs.sh \
           && if [ -n "${{ env.REMOVE_PATCHES }}" ]; then echo "(cd ../build/pkgs/${{ env.SPKG }}/patches && rm -f ${{ env.REMOVE_PATCHES }}; :)" >> upstream/update-pkgs.sh; fi \
-          && echo 'echo ntl flint readline mpfr cddlib 4ti2 > ../build/pkgs/singular/dependencies' >> upstream/update-pkgs.sh \
+          && echo 'echo ntl flint readline mpfr cddlib 4ti2 info > ../build/pkgs/singular/dependencies' >> upstream/update-pkgs.sh \
           && ls -l upstream/
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -1,4 +1,4 @@
-name: Run Sage CI for Linux/macOS
+name: Sage CI
 
 ## This GitHub Actions workflow provides:
 ##

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -106,7 +106,7 @@ jobs:
       targets_pre: SAGE_CHECK=no singular-build-deps
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular V=1 singular
       targets_optional: SAGE_CHECK=no SAGE_CHECK_pysingular=warn pysingular
-      timeout: 3000
+      timeout: 5000
       # Standard setting: Test the current beta release of Sage:
       sage_repo: sagemath/sage
       sage_ref: develop
@@ -128,7 +128,7 @@ jobs:
       targets_pre: SAGE_CHECK=no singular-build-deps
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular V=1 singular
       targets_optional: SAGE_CHECK=no SAGE_CHECK_pysingular=warn pysingular
-      timeout: 3000
+      timeout: 5000
       # Standard setting: Test the current beta release of Sage:
       sage_repo: sagemath/sage
       sage_ref: develop
@@ -148,7 +148,7 @@ jobs:
       targets_pre: SAGE_CHECK=no singular-build-deps
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular V=1 singular
       targets_optional: SAGE_CHECK=no SAGE_CHECK_pysingular=warn pysingular
-      timeout: 3000
+      timeout: 5000
       sage_repo:         sagemath/sage
       sage_ref:          refs/pull/37237/head
       #sage_ref:          develop

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -104,7 +104,7 @@ jobs:
       extra_sage_packages: "info"
       # Sage distribution packages to build
       targets_pre: SAGE_CHECK=no singular-build-deps
-      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular V=1 singular
+      targets: GITHUB_ACTIONS=1 SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular V=1 singular
       targets_optional: SAGE_CHECK=no SAGE_CHECK_pysingular=warn pysingular
       timeout: 5000
       # Standard setting: Test the current beta release of Sage:
@@ -126,7 +126,7 @@ jobs:
       extra_sage_packages: "info"
       # Sage distribution packages to build
       targets_pre: SAGE_CHECK=no singular-build-deps
-      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular V=1 singular
+      targets: GITHUB_ACTIONS=1 SAGE_CHECK=no SAGE_CHECK_PACKAGES=singular V=1 singular
       targets_optional: SAGE_CHECK=no SAGE_CHECK_pysingular=warn pysingular
       timeout: 5000
       # Standard setting: Test the current beta release of Sage:

--- a/doc/Makefile-docbuild.in
+++ b/doc/Makefile-docbuild.in
@@ -97,7 +97,7 @@ IMAGES_HTML := $(IMAGES:%=${HTML_SUBDIR}/%)
 
 # prepend bindir to path so that programs from there are taken first.
 # prepending the .libs directories is needed on Cygwin for finding the .dll files
-export PATH := "${bindir}:${top_builddir}/libpolys/polys/.libs:${top_builddir}/Singular/.libs:${top_builddir}/omalloc/.libs:${top_builddir}/factory/.libs:${top_builddir}/resources/.libs:${PATH}"
+export PATH := ${bindir}:${top_builddir}/libpolys/polys/.libs:${top_builddir}/Singular/.libs:${top_builddir}/omalloc/.libs:${top_builddir}/factory/.libs:${top_builddir}/resources/.libs:${PATH}
 
 ###########################################################
 # top targets

--- a/doc/doc2tex.pl
+++ b/doc/doc2tex.pl
@@ -394,8 +394,16 @@ sub HandleExample
     {
       last if (/^STDIN\s*([0-9]+)..\$/);
       # check for error
-      Error("while running example $ex_prefix from $doc_file:$lline.\nCall: '$Singular $Singular_opts $ex_file > $res_file'\n")
-	if (/error occurred/ && ! $error_ok);
+      if (/error occurred/ && ! $error_ok)
+      {
+        if ($ENV{GITHUB_ACTIONS})
+        {
+          print STDERR "::group::${$res_file}";
+          &System("cat $res_file >&2");
+          print STDERR "::endgroup::";
+        }
+        Error("while running example $ex_prefix from $doc_file:$lline.\nCall: '$Singular $Singular_opts $ex_file > $res_file'\n");
+      }
       # remove stuff from echo
       if (/^$ex_file\s*([0-9]+)../)
       {

--- a/doc/singular.doc
+++ b/doc/singular.doc
@@ -1307,7 +1307,7 @@ Todos/Issues:
 @c ----------------------------------------------------------
 @node sagbiNormaliz_lib
 @subsection sagbiNormaliz_lib
-@c lib sagbiNormaliz.lib
+@c lib sagbiNormaliz.lib tag:normaliz
 @c ----------------------------------------------------------
 @node stanleyreisner_lib
 @subsection stanleyreisner_lib


### PR DESCRIPTION
To fix this build failure seen in https://github.com/Singular/Singular/actions/runs/7557525633/job/20577033209#step:11:4703
```
  [singular-git]   ><lib sagbiNormaliz make[5]: *** No rule to make target 'd2t_singular/sagbiNormaliz_lib.tex'.
  [singular-git]   
  [singular-git]   **** Error: non-zero exit status of system call: 'make -f Makefile-docbuild  --no-print-directory -s  VERBOSE=1 ./d2t_singular/sagbiNormaliz_lib.tex': Inappropriate ioctl for device
  [singular-git]   make[4]: *** [Makefile-docbuild:173: singular.tex] Error 1
  [singular-git]   sed -e "s/BR_PLURAL_BR/(plural)/g" <plural.tex >s-plural.tex
  [singular-git]   sed -e "s/BR_PLURAL_BR/(plural)/g" <plulibs.tex >s-plulibs.tex
  [singular-git]   sed -e "s/BR_LETTERPLACE_BR/(letterplace)/g" <letterplace.tex >s-letterplace.tex
  [singular-git]   make[4]: Target 'singular.info' not remade because of errors.
  [singular-git]   make[3]: *** [Makefile:630: singular.info] Error 2
  [singular-git]   ********************************************************************************
```
