### PR TITLE
**/Makefile.am: links tests with RESOURCES_LIBS

### DIFF
--- a/Singular/Makefile.am
+++ b/Singular/Makefile.am
@@ -162,7 +162,7 @@ dist_script_SCRIPTS = singularsurf singularsurf_jupyter singularsurf_win surfex
 ESingular_CPPFLAGS = ${AM_CPPFLAGS} -DESINGULAR -DPROTO
 ESingular_LDADD =  ${top_builddir}/libpolys/reporter/libreporter.la \
 ${top_builddir}/libpolys/misc/libmisc.la ${OMALLOC_LIBS} \
-${top_builddir}/resources/libsingular_resources.la
+$(RESOURCES_LIBS)
 
 
 ESingular_SOURCES = emacs.cc feOptES.inc feOpt.cc
@@ -171,7 +171,7 @@ ESingular_SOURCES = emacs.cc feOptES.inc feOpt.cc
 TSingular_CPPFLAGS = ${AM_CPPFLAGS} -DTSINGULAR -DPROTO
 TSingular_LDADD = ${top_builddir}/libpolys/reporter/libreporter.la \
 ${top_builddir}/libpolys/misc/libmisc.la ${OMALLOC_LIBS} \
-${top_builddir}/resources/libsingular_resources.la
+$(RESOURCES_LIBS)
 
 TSingular_SOURCES = emacs.cc feOptTS.inc feOpt.cc
 # utils.cc utils.h
@@ -213,7 +213,7 @@ TESTS=test
 check_PROGRAMS=$(TESTS)
 
 test_SOURCES = test.cc
-test_LDADD = ${builddir}/../omalloc/libomalloc.la libSingular.la
+test_LDADD = $(OMALLOC_LIBS) libSingular.la $(RESOURCES_LIBS)
 
 #########################################################
 # These files are built first

--- a/kernel/GBEngine/Makefile.am
+++ b/kernel/GBEngine/Makefile.am
@@ -21,7 +21,7 @@ TESTS_ENVIRONMENT += SINGULAR_ROOT_DIR='${abs_top_builddir}'
 TESTS = test
 check_PROGRAMS = $(TESTS)
 test_SOURCES = test.cc
-test_LDADD   = libGBEngine.la ${builddir}/../../omalloc/libomalloc.la ${builddir}/../combinatorics/libcombinatorics.la ${builddir}/../linear_algebra/liblinear_algebra.la ${builddir}/../libkernelCommon.la  ${builddir}/../../Singular/libSingular.la
+test_LDADD   = libGBEngine.la $(OMALLOC_LIBS) ${builddir}/../combinatorics/libcombinatorics.la ${builddir}/../linear_algebra/liblinear_algebra.la ${builddir}/../libkernelCommon.la  ${builddir}/../../Singular/libSingular.la $(RESOURCES_LIBS)
 
 CLEANFILES = $(TESTS)
 

--- a/kernel/Makefile.am
+++ b/kernel/Makefile.am
@@ -51,7 +51,7 @@ TESTS = test
 check_PROGRAMS = $(TESTS)
 
 test_SOURCES = test.cc
-test_LDADD   = libkernel.la ${builddir}/../omalloc/libomalloc.la ${builddir}/../Singular/libSingular.la
+test_LDADD   = libkernel.la $(OMALLOC_LIBS) ${builddir}/../Singular/libSingular.la $(RESOURCES_LIBS)
 
 # These files are built first
 # BUILT_SOURCES = MOD

--- a/kernel/combinatorics/Makefile.am
+++ b/kernel/combinatorics/Makefile.am
@@ -17,6 +17,6 @@ TESTS_ENVIRONMENT += SINGULAR_ROOT_DIR='${abs_top_builddir}'
 TESTS = test
 check_PROGRAMS = $(TESTS)
 test_SOURCES = test.cc
-test_LDADD   = libcombinatorics.la ${builddir}/../libkernelCommon.la ${builddir}/../../omalloc/libomalloc.la ${builddir}/../../Singular/libSingular.la
+test_LDADD   = libcombinatorics.la ${builddir}/../libkernelCommon.la $(OMALLOC_LIBS) ${builddir}/../../Singular/libSingular.la $(RESOURCES_LIBS)
 
 CLEANFILES = $(TESTS)

--- a/kernel/fglm/Makefile.am
+++ b/kernel/fglm/Makefile.am
@@ -17,6 +17,6 @@ TESTS_ENVIRONMENT += SINGULAR_ROOT_DIR='${abs_top_builddir}'
 TESTS = test
 check_PROGRAMS = $(TESTS)
 test_SOURCES = test.cc
-test_LDADD   = libfglm.la ${builddir}/../../omalloc/libomalloc.la ${builddir}/../../Singular/libSingular.la
+test_LDADD   = libfglm.la $(OMALLOC_LIBS) ${builddir}/../../Singular/libSingular.la $(RESOURCES_LIBS)
 
 CLEANFILES = $(TESTS)

--- a/kernel/groebner_walk/Makefile.am
+++ b/kernel/groebner_walk/Makefile.am
@@ -17,6 +17,6 @@ TESTS_ENVIRONMENT += SINGULAR_ROOT_DIR='${abs_top_builddir}'
 TESTS = test
 check_PROGRAMS = $(TESTS)
 test_SOURCES = test.cc
-test_LDADD   = libgroebner_walk.la ${builddir}/../../omalloc/libomalloc.la ${builddir}/../../Singular/libSingular.la
+test_LDADD   = libgroebner_walk.la $(OMALLOC_LIBS) ${builddir}/../../Singular/libSingular.la $(RESOURCES_LIBS)
 
 CLEANFILES = $(TESTS)

--- a/kernel/linear_algebra/Makefile.am
+++ b/kernel/linear_algebra/Makefile.am
@@ -23,6 +23,6 @@ TESTS_ENVIRONMENT += SINGULAR_ROOT_DIR='${abs_top_builddir}'
 TESTS = test
 check_PROGRAMS = $(TESTS)
 test_SOURCES = test.cc
-test_LDADD   = liblinear_algebra.la ${builddir}/../../omalloc/libomalloc.la ${builddir}/../../Singular/libSingular.la
+test_LDADD   = liblinear_algebra.la $(OMALLOC_LIBS) ${builddir}/../../Singular/libSingular.la $(RESOURCES_LIBS)
 
 CLEANFILES = $(TESTS)

--- a/kernel/maps/Makefile.am
+++ b/kernel/maps/Makefile.am
@@ -17,6 +17,6 @@ TESTS_ENVIRONMENT += SINGULAR_ROOT_DIR='${abs_top_builddir}'
 TESTS = test
 check_PROGRAMS = $(TESTS)
 test_SOURCES = test.cc
-test_LDADD   = libmaps.la ${builddir}/../../omalloc/libomalloc.la ${builddir}/../../Singular/libSingular.la
+test_LDADD   = libmaps.la $(OMALLOC_LIBS) ${builddir}/../../Singular/libSingular.la $(RESOURCES_LIBS)
 
 CLEANFILES = $(TESTS)

--- a/kernel/numeric/Makefile.am
+++ b/kernel/numeric/Makefile.am
@@ -18,6 +18,6 @@ TESTS_ENVIRONMENT += SINGULAR_ROOT_DIR='${abs_top_builddir}'
 TESTS = test
 check_PROGRAMS = $(TESTS)
 test_SOURCES = test.cc
-test_LDADD   = libnumeric.la ${builddir}/../../omalloc/libomalloc.la ${builddir}/../../Singular/libSingular.la
+test_LDADD   = libnumeric.la $(OMALLOC_LIBS) ${builddir}/../../Singular/libSingular.la $(RESOURCES_LIBS)
 
 CLEANFILES = $(TESTS)

--- a/kernel/oswrapper/Makefile.am
+++ b/kernel/oswrapper/Makefile.am
@@ -19,6 +19,6 @@ TESTS_ENVIRONMENT += SINGULAR_ROOT_DIR='${abs_top_builddir}'
 TESTS = test
 check_PROGRAMS = $(TESTS)
 test_SOURCES = test.cc
-test_LDADD   = liboswrapper.la ${builddir}/../../omalloc/libomalloc.la ${builddir}/../../Singular/libSingular.la
+test_LDADD   = liboswrapper.la $(OMALLOC_LIBS) ${builddir}/../../Singular/libSingular.la $(RESOURCES_LIBS)
 
 CLEANFILES = $(TESTS)

--- a/kernel/spectrum/Makefile.am
+++ b/kernel/spectrum/Makefile.am
@@ -17,6 +17,6 @@ TESTS_ENVIRONMENT += SINGULAR_ROOT_DIR='${abs_top_builddir}'
 TESTS = test
 check_PROGRAMS = $(TESTS)
 test_SOURCES = test.cc
-test_LDADD   = libspectrum.la ${builddir}/../../omalloc/libomalloc.la ${builddir}/../../Singular/libSingular.la
+test_LDADD   = libspectrum.la $(OMALLOC_LIBS) ${builddir}/../../Singular/libSingular.la $(RESOURCES_LIBS)
 
 CLEANFILES = $(TESTS)


### PR DESCRIPTION
Several test programs use functions from libsingular_resources, such as `feInitResources()`. Here we ensure that those test programs are actually linked with libsingular_resources by adding `RESOURCES_LIBS` to the corresponding `LDADD` lines. In the process, and for consistency, we have replaced some references to `libomalloc.la` with `OMALLOC_LIBS`.