### PR TITLE
install modules under /usr/lib

### DIFF
--- a/Singular/dyn_modules/Order/Makefile.am
+++ b/Singular/dyn_modules/Order/Makefile.am
@@ -16,7 +16,7 @@ if SI_BUILTIN_ORDER
   P_PROCS_MODULE_LDFLAGS = -module
 else
   module_LTLIBRARIES=Order.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS = -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/bigintm/Makefile.am
+++ b/Singular/dyn_modules/bigintm/Makefile.am
@@ -7,7 +7,7 @@ if SI_BUILTIN_BIGINTM
   P_PROCS_MODULE_LDFLAGS  = -module
 else
   module_LTLIBRARIES=bigintm.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS = -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/cohomo/Makefile.am
+++ b/Singular/dyn_modules/cohomo/Makefile.am
@@ -6,7 +6,7 @@ if SI_BUILTIN_COHOMO
   P_PROCS_CPPFLAGS_COMMON = -DSTATIC_VERSION
 else
   module_LTLIBRARIES=cohomo.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS = -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/customstd/Makefile.am
+++ b/Singular/dyn_modules/customstd/Makefile.am
@@ -13,7 +13,7 @@ if SI_BUILTIN_CUSTOMSTD
   P_PROCS_MODULE_LDFLAGS  = -module
 else
   module_LTLIBRARIES=customstd.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS =  -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/freealgebra/Makefile.am
+++ b/Singular/dyn_modules/freealgebra/Makefile.am
@@ -6,7 +6,7 @@ if SI_BUILTIN_FREEALGEBRA
   P_PROCS_CPPFLAGS_COMMON = -DSTATIC_VERSION
 else
   module_LTLIBRARIES=freealgebra.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS = -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/gfanlib/Makefile.am
+++ b/Singular/dyn_modules/gfanlib/Makefile.am
@@ -18,7 +18,7 @@ else
 if HAVE_GFANLIB
   module_LTLIBRARIES=gfanlib.la
 endif
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS =  -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/gitfan/Makefile.am
+++ b/Singular/dyn_modules/gitfan/Makefile.am
@@ -13,7 +13,7 @@ if SI_BUILTIN_GITFAN
   P_PROCS_MODULE_LDFLAGS  = -module
 else
   module_LTLIBRARIES=gitfan.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS =  -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/interval/Makefile.am
+++ b/Singular/dyn_modules/interval/Makefile.am
@@ -11,7 +11,7 @@ if SI_BUILTIN_INTERVAL
   P_PROCS_MODULE_LDFLAGS = -module
 else
   module_LTLIBRARIES=interval.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS = -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/loctriv/Makefile.am
+++ b/Singular/dyn_modules/loctriv/Makefile.am
@@ -6,7 +6,7 @@ if SI_BUILTIN_LOCTRIV
   P_PROCS_CPPFLAGS_COMMON = -DSTATIC_VERSION
 else
   module_LTLIBRARIES=loctriv.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS = -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/machinelearning/Makefile.am
+++ b/Singular/dyn_modules/machinelearning/Makefile.am
@@ -7,7 +7,7 @@ if SI_BUILTIN_MACHINELEARNING
   P_PROCS_MODULE_LDFLAGS  = -module
 else !SI_BUILTIN_MACHINELEARNING
   module_LTLIBRARIES = machinelearning.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS = -module -export-dynamic -avoid-version
 endif !SI_BUILTIN_MACHINELEARNING

--- a/Singular/dyn_modules/partialgb/Makefile.am
+++ b/Singular/dyn_modules/partialgb/Makefile.am
@@ -6,7 +6,7 @@ if SI_BUILTIN_PARTIALGB
   P_PROCS_CPPFLAGS_COMMON = -DSTATIC_VERSION
 else
   module_LTLIBRARIES=partialgb.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS = -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/polymake/Makefile.am
+++ b/Singular/dyn_modules/polymake/Makefile.am
@@ -14,7 +14,7 @@ if SI_BUILTIN_POLYMAKE
   P_PROCS_MODULE_LDFLAGS  = -module
 else
   module_LTLIBRARIES=polymake.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS =  -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/pyobject/Makefile.am
+++ b/Singular/dyn_modules/pyobject/Makefile.am
@@ -7,7 +7,7 @@ if SI_BUILTIN_PYOBJECT
   P_PROCS_MODULE_LDFLAGS  = -module
 else !SI_BUILTIN_PYOBJECT
   module_LTLIBRARIES = pyobject.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS = -module -export-dynamic -avoid-version
 ###  -export-dynamic -shared -module -avoid-version (add to all DMs?)

--- a/Singular/dyn_modules/python/Makefile.am
+++ b/Singular/dyn_modules/python/Makefile.am
@@ -20,7 +20,7 @@ if SI_BUILTIN_PYTHON_MODULE
   P_PROCS_MODULE_LDFLAGS  = -module
 else
   module_LTLIBRARIES=python_module.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS =  -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/singmathic/Makefile.am
+++ b/Singular/dyn_modules/singmathic/Makefile.am
@@ -6,7 +6,7 @@ if SI_BUILTIN_SINGMATHIC
   P_PROCS_MODULE_LDFLAGS  = -module
 else
   module_LTLIBRARIES=singmathic.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS = -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/sispasm/Makefile.am
+++ b/Singular/dyn_modules/sispasm/Makefile.am
@@ -6,7 +6,7 @@ if SI_BUILTIN_SISPASM
   P_PROCS_CPPFLAGS_COMMON = -DSTATIC_VERSION
 else
   module_LTLIBRARIES=sispasm.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS = -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/subsets/Makefile.am
+++ b/Singular/dyn_modules/subsets/Makefile.am
@@ -6,7 +6,7 @@ if SI_BUILTIN_SUBSETS
   P_PROCS_CPPFLAGS_COMMON = -DSTATIC_VERSION
 else
   module_LTLIBRARIES=subsets.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS = -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/systhreads/Makefile.am
+++ b/Singular/dyn_modules/systhreads/Makefile.am
@@ -11,7 +11,7 @@ if SI_BUILTIN_SYSTHREADS
   P_PROCS_MODULE_LDFLAGS = -module
 else
   module_LTLIBRARIES=systhreads.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS = -module -export-dynamic -avoid-version
 endif

--- a/Singular/dyn_modules/syzextra/Makefile.am
+++ b/Singular/dyn_modules/syzextra/Makefile.am
@@ -11,7 +11,7 @@ if SI_BUILTIN_SYZEXTRA
   P_PROCS_MODULE_LDFLAGS = -module
 else
   module_LTLIBRARIES=syzextra.la
-  moduledir = $(libexecdir)/singular/MOD
+  moduledir = $(libdir)/singular/MOD
   P_PROCS_CPPFLAGS_COMMON = -DDYNAMIC_VERSION
   P_PROCS_MODULE_LDFLAGS = -module -export-dynamic -avoid-version
 endif


### PR DESCRIPTION
Install modules (plugins) under the /usr/lib hierarchy instead of installing them under the /usr/libexec hierarchy.