### PR TITLE
fix hilbpoly for empty ideal

### DIFF
--- a/Singular/LIB/polylib.lib
+++ b/Singular/LIB/polylib.lib
@@ -58,7 +58,7 @@ EXAMPLE: example hilbPoly; shows an example
    bigintvec v=hilb(I,2);
    int s=dim(I);
    intvec hp;
-   if(s==0){return(hp);}
+   if(s<=0){return(hp);}
    int d=size(v)-2;
    ring S=0,t,dp;
    poly p=v[1+d]*bino(s-1-d,s-1);


### PR DESCRIPTION
To help fix https://github.com/sagemath/sage/issues/33808

The output for the ideal (1) should be `[]` as for ideals of finite nonzero codimension.