### PR TITLE
fix some typos in header .h files

### DIFF
--- a/Singular/attrib.h
+++ b/Singular/attrib.h
@@ -24,7 +24,7 @@ class sattr
     char *  name;
     void *  data;
     attr    next;
-    int     atyp; /* the type of the attribut, describes the data field
+    int     atyp; /* the type of the attribute, describes the data field
                   */
 
     void Print();

--- a/Singular/blackbox.h
+++ b/Singular/blackbox.h
@@ -48,7 +48,7 @@ struct  blackbox_struct
   BOOLEAN (*blackbox_deserialize)(blackbox **b,void **d, si_link f);
   /// additional type info
   void *data;
-  /// addtinional gneral properties
+  /// additional general properties
   int properties; // bit 0:blackbox is only a wrapper for lists
 #define  BB_LIKE_LIST(B) ((B)->properties &1)
 } ;

--- a/Singular/cntrlc.h
+++ b/Singular/cntrlc.h
@@ -4,7 +4,7 @@
 *  Computer Algebra System SINGULAR     *
 ****************************************/
 /*
-* ABSTRACT - interupt and signal handling
+* ABSTRACT - interrupt and signal handling
 */
 #include <setjmp.h>
 #include "kernel/mod2.h"

--- a/Singular/countedref.h
+++ b/Singular/countedref.h
@@ -61,7 +61,7 @@ public:
   CountedRefPtr(const CountedRefPtr<ptr_type, !nondestructive, Never, count_type>& rhs):
     m_ptr(rhs.m_ptr) { reclaim(); }
 
-  /// Construct refernce copy
+  /// Construct reference copy
   CountedRefPtr(const self& rhs):
     m_ptr(rhs.m_ptr) { reclaim(); }
 
@@ -106,7 +106,7 @@ private:
 };
 
 /** @class RefCounter
- * This class implements implements a refernce counter which we can use
+ * This class implements implements a reference counter which we can use
  * as a public base of objects managed by @CountedRefPtr.
  **/
 class RefCounter {
@@ -208,7 +208,7 @@ private:
 
 /** @class LeftvHelper
  * This class implements some recurrent code sniplets to be used with
- * @c leftv and @c idhdl.implements a refernce counter which we can use
+ * @c leftv and @c idhdl.implements a reference counter which we can use
  **/
 class LeftvHelper {
 public:
@@ -275,7 +275,7 @@ public:
 };
 
 /** @class LeftvShallow
- * Ths class wraps @c leftv by taking into acount memory allocation, destruction
+ * This class wraps @c leftv by taking into account memory allocation, destruction
  * as well as shallowly copying of a given @c leftv, i.e. we just copy auxiliary
  * information (like subexpressions), but not the actual data.
  *
@@ -321,7 +321,7 @@ protected:
 };
 
 /** @class LeftvDeep
- * This class wraps @c leftv by taking into acount memory allocation, destruction
+ * This class wraps @c leftv by taking into account memory allocation, destruction
  * as well as deeply copying of a given @c leftv, i.e. we also take over
  * ownership of the @c leftv data.
  *

--- a/Singular/feOpt.h
+++ b/Singular/feOpt.h
@@ -62,7 +62,7 @@ inline int feOptValue(feOptIndex opt, int* val)
   return FALSE;
 }
 
-// maps name to otions
+// maps name to options
 feOptIndex feGetOptIndex(const char* name);
 feOptIndex feGetOptIndex(int optc);
 

--- a/Singular/feOptTab.h
+++ b/Singular/feOptTab.h
@@ -45,7 +45,7 @@ VAR struct fe_option feOptSpec[] =
 // The order in which options are specified is the order in which
 // their help is printed on -h
 //
-// Options whose hel starts with an "//" are considered undocumented,
+// Options whose help starts with an "//" are considered undocumented,
 // i.e., their help is not printed on -h
 //
 #if defined(ESINGULAR) || defined(TSINGULAR)

--- a/Singular/fglm.cc
+++ b/Singular/fglm.cc
@@ -35,7 +35,7 @@
 
 
 // internal Version: 1.18.1.6
-//     enumeration to handle the various errors to occour.
+//     enumeration to handle the various errors to occur.
 enum FglmState{
     FglmOk,
     FglmHasOne,
@@ -272,7 +272,7 @@ fglmIdealcheck( const ideal theIdeal )
 
 // The main function for the fglm-Algorithm.
 // Checks the input-data, and calls fglmzero (see fglmzero.cc).
-// Returns the new groebnerbasis or 0 if an error occoured.
+// Returns the new groebnerbasis or 0 if an error occured.
 BOOLEAN
 fglmProc( leftv result, leftv first, leftv second )
 {
@@ -406,7 +406,7 @@ ideal fglmQuot( ideal first, poly second )
 
 // fglmQuotProc: Calculate I:f with FGLM methods.
 // Checks the input-data, and calls fglmquot (see fglmzero.cc).
-// Returns the new groebnerbasis if I:f or 0 if an error occoured.
+// Returns the new groebnerbasis if I:f or 0 if an error occured.
 BOOLEAN
 fglmQuotProc( leftv result, leftv first, leftv second )
 {
@@ -536,7 +536,7 @@ ideal findUni( ideal first )
 // The main function for finduni().
 // Checks the input-data, and calls FindUnivariateWrapper (see fglmzero.cc).
 // Returns an ideal containing the univariate Polynomials or 0 if an error
-// has occoured.
+// has occured.
 BOOLEAN
 findUniProc( leftv result, leftv first )
 {

--- a/Singular/fglm.h
+++ b/Singular/fglm.h
@@ -11,7 +11,7 @@
 // first is the sourceRing, second is the given ideal in sourceRing.
 // Returns the groebnerbasis of the sourceIdeal in the currentRing.
 // Checks, if the ideal is really a reduced groebner basis of a
-// 0-dimensional Ideal. Returns TRUE if an error occoured.
+// 0-dimensional Ideal. Returns TRUE if an error occurred.
 BOOLEAN fglmProc( leftv result, leftv first, leftv second );
 
 // fglmquotproc(...):
@@ -21,7 +21,7 @@ BOOLEAN fglmProc( leftv result, leftv first, leftv second );
 // Returns the groebnerbasis of I:q in the currentRing.
 // Checks, if the ideal is really a reduced groebner basis of a
 // 0-dimensional Ideal and if q is really reduced.
-//  Returns TRUE if an error occoured.
+//  Returns TRUE if an error occurred.
 BOOLEAN fglmQuotProc( leftv result, leftv first, leftv second );
 ideal fglmQuot( ideal first, poly second );
 

--- a/Singular/ipid.h
+++ b/Singular/ipid.h
@@ -5,7 +5,7 @@
 ****************************************/
 
 /*
-* ABSTRACT: identfier handling
+* ABSTRACT: identifier handling
 */
 #include "misc/options.h"
 #include "Singular/idrec.h"

--- a/Singular/ipshell.h
+++ b/Singular/ipshell.h
@@ -68,7 +68,7 @@ char *  iiGetLibProcBuffer( procinfov pi, int part=1 );
 char *  iiProcName(char *buf, char & ct, char* &e);
 char *  iiProcArgs(char *e,BOOLEAN withParenth);
 BOOLEAN iiLibCmd( const char *newlib, BOOLEAN autoexport, BOOLEAN tellerror, BOOLEAN force );
-/* sees wheter library lib has already been loaded
+/* sees whether library lib has already been loaded
    if yes, writes filename of lib into where and returns TRUE,
    if  no, returns FALSE
 */
@@ -168,7 +168,7 @@ extern const struct sValCmdM dArithM[];
 #endif
 
 /* ================================================================== */
-/* Assigments : */
+/* Assignments : */
 BOOLEAN iiAssign(leftv left, leftv right, BOOLEAN toplevel=TRUE);
 coeffs jjSetMinpoly(coeffs cf, number a);
 

--- a/Singular/linearAlgebra_ip.h
+++ b/Singular/linearAlgebra_ip.h
@@ -5,7 +5,7 @@
 
 /**
  * Computes all eigenvalues of a given real quadratic matrix with
- * multiplicites.
+ * multiplicities.
  *
  * The method assumes that the current ground field is the complex numbers.
  * Computations are based on the QR double shift algorithm involving

--- a/Singular/misc_ip.h
+++ b/Singular/misc_ip.h
@@ -48,7 +48,7 @@
  * We thus have: n = L[1][1]^L[2][1] * ... * L[1][k]^L[2][k] * L[3], where
  * k is the number of mutually distinct prime factors (<= a provided non-
  * zero bound).
- * Note that for n = 0, L[1] and L[2] will be emtpy lists and L[3] will be
+ * Note that for n = 0, L[1] and L[2] will be empty lists and L[3] will be
  * zero.
  *
  * @return the factorisation data in a SINGULAR-internal list

--- a/Singular/mod_lib.h
+++ b/Singular/mod_lib.h
@@ -29,7 +29,7 @@ lib_types type_of_LIB(const char *newlib, char *fullname);
 # define SI_BUILTIN_MATHIC(add) add(singmathic)
 #endif
 #ifdef EMBED_PYTHON
-//TODO: the line above means that syzextra should be staticly embedded IFF pyobjects do so :(((((
+//TODO: the line above means that syzextra should be statically embedded IFF pyobjects do so :(((((
 #define SI_BUILTIN_PYOBJECT(add) add(pyobject) add(syzextra) SI_BUILTIN_GFANLIB(add) SI_BUILTIN_MATHIC(add)
 #endif
 */

--- a/Singular/subexpr.h
+++ b/Singular/subexpr.h
@@ -90,8 +90,8 @@ class sleftv
     BITSET      flag;
     int         rtyp;
                  /* the type of the expression, describes the data field
-                  * (E) markes the type field in iparith
-                  * (S) markes the rtyp in sleftv
+                  * (E) marks the type field in iparith
+                  * (S) marks the rtyp in sleftv
                   * ANY_TYPE:   data is int: real type or 0    (E)
                   * DEF_CMD:    all types, no change in sleftv (E)
                   * IDHDL: existing variable         (E)

--- a/Singular/svd_si.h
+++ b/Singular/svd_si.h
@@ -8001,7 +8001,7 @@ namespace svd
         {
 
             //
-            // We cant use additional memory or there is no need in such operations
+            // We cannot use additional memory or there is no need in such operations
             //
             result = bdsvd::rmatrixbdsvd<Precision>(w, e, minmn, isupper, false, u, nru, a, 0, vt, ncvt);
         }
@@ -8269,7 +8269,7 @@ namespace svd
         {
 
             //
-            // We cant use additional memory or there is no need in such operations
+            // We cannot use additional memory or there is no need in such operations
             //
             result = bdsvd::bidiagonalsvddecomposition<Precision>(w, e, minmn, isupper, false, u, nru, a, 0, vt, ncvt);
         }

--- a/Singular/table.h
+++ b/Singular/table.h
@@ -1,6 +1,6 @@
 #ifdef IPARITH
 // additional to the usual types: INT_CMD etc.
-// thre are special types:
+// there are special types:
 // for the input:
 // IDHDL: argument must have a name
 // DEF_CMD: no restriktions on the argument
@@ -22,7 +22,7 @@
 // ALLOW_NC: also for plural rings and letterplace rings
 // ALLOW_LP: also for letterplace rings, not for plural rings
 // ALLOW_PLURAL: not for letterplace rings, but for plural rings
-// COMM_PLURAL: only for commuative subrings of plural rings
+// COMM_PLURAL: only for commutative subrings of plural rings
 // NO_NC: not for non-commutative rings
 //
 // coefficient domain:

--- a/Singular/tok.h
+++ b/Singular/tok.h
@@ -19,9 +19,9 @@ EXTERN_VAR char     my_yylinebuf[80];
 extern int  yyparse(void);
 #endif
 
-/* the follwing defines for infix operators should not be changed: *
+/* the following defines for infix operators should not be changed: *
 *  grammar.y does not use the symbolic names                       *
-*  scanner.l uses the identies for some optimzations              */
+*  scanner.l uses the identities for some optimizations              */
 #define LOGIC_OP         '&'
 #define MULDIV_OP        '/'
 #define COMP_OP          '<'

--- a/Singular/walk_ip.cc
+++ b/Singular/walk_ip.cc
@@ -45,7 +45,7 @@
 ///////////////////////////////////////////////////////////////////
 //Description: The main function for the Walk-Algorithm. Checks the
 //input-data, and calls walk64 (see walkMain.cc). Returns the new
-//groebner basis or something else if an error occoured.
+//groebner basis or something else if an error occured.
 ///////////////////////////////////////////////////////////////////
 //Uses: omAlloc0,walkConsistency,rGetGlobalOrderWeightVec,
 //omFreeSize,sizeof,IDIDEAL,walk64,rSetHdl,idrMoveR,Werror,idInit


### PR DESCRIPTION
this one is for fixing all typos in `.h` files found using `codespell`