### PR TITLE
pp_Mult_qq: run _p_Mult_q_Normal_ZeroDiv on the copy of q

### DIFF
--- a/libpolys/polys/monomials/p_polys.h
+++ b/libpolys/polys/monomials/p_polys.h
@@ -1183,7 +1183,7 @@ static inline poly pp_Mult_qq(poly p, poly q, const ring r)
 #endif
 #ifdef HAVE_RINGS
   if (UNLIKELY(!nCoeff_is_Domain(r->cf)))
-    return _p_Mult_q_Normal_ZeroDiv(p, q, 1, r);
+    res = _p_Mult_q_Normal_ZeroDiv(p, qq, 1, r);
   else
 #endif
     res = _p_Mult_q(p, qq, 1, r);


### PR DESCRIPTION
Also makes sure to delete it if needed.

Fixes https://github.com/sagemath/sage/pull/38158#issuecomment-2157507966