### PR TITLE
Improve symbol exports on Windows

### DIFF
--- a/factory/canonicalform.h
+++ b/factory/canonicalform.h
@@ -202,13 +202,13 @@ public:
     friend class CFIterator;
 };
 
-CF_INLINE CanonicalForm
+CF_INLINE FACTORY_PUBLIC CanonicalForm
 operator + ( const CanonicalForm&, const CanonicalForm& );
 
 CF_NO_INLINE FACTORY_PUBLIC CanonicalForm
 operator - ( const CanonicalForm&, const CanonicalForm& );
 
-CF_INLINE CanonicalForm
+CF_INLINE FACTORY_PUBLIC CanonicalForm
 operator * ( const CanonicalForm&, const CanonicalForm& );
 
 CF_NO_INLINE FACTORY_PUBLIC CanonicalForm

--- a/factory/cf_hnf.h
+++ b/factory/cf_hnf.h
@@ -19,7 +19,7 @@
  *
 **/
 
-CFMatrix* FACTORY_PUBLIC cf_HNF(CFMatrix& A);
+CFMatrix* cf_HNF(CFMatrix& A);
 
 /**
  * performs LLL reduction.
@@ -41,7 +41,7 @@ CFMatrix* FACTORY_PUBLIC cf_HNF(CFMatrix& A);
  * @note: uses NTL or FLINT
 **/
 
-CFMatrix* FACTORY_PUBLIC cf_LLL(CFMatrix& A);
+CFMatrix* cf_LLL(CFMatrix& A);
 
 /*ENDPUBLIC*/
 

--- a/factory/cf_roots.h
+++ b/factory/cf_roots.h
@@ -1,7 +1,7 @@
 #ifndef CF_ROOTS_H
 #define CF_ROOTS_H
 
-int* FACTORY_PUBLIC Zp_roots (const CanonicalForm f);
+int* Zp_roots (const CanonicalForm f);
 
 
 #endif

--- a/factory/globaldefs.h
+++ b/factory/globaldefs.h
@@ -15,7 +15,7 @@
 #define THREAD_VAR __thread
 #endif
 
-#if defined(__CYGWIN__) && defined(DLL_EXPORT)
+#if (defined _WIN32 || defined(__CYGWIN__))
   #ifdef FACTORY_BUILDING_DLL
     #define FACTORY_PUBLIC __declspec(dllexport)
   #else

--- a/factory/variable.h
+++ b/factory/variable.h
@@ -82,7 +82,7 @@ public:
      *  Use it to define algebraic variables
      *  @note: algebraic variables have a level < 0
     **/
-    friend Variable rootOf( const CanonicalForm &, char name );
+    friend Variable FACTORY_PUBLIC rootOf( const CanonicalForm &, char name );
 };
 
 /** returns a symbolic root of polynomial with name @a name


### PR DESCRIPTION
I'm currently working on compiling the factory part of Singular with MSVC. This PR is the first in a series that fixes a few small issues that I've encountered.

Here we fix the compiler error
```
..\subprojects\factory\factory\cf_hnf.h(22): error C2059: syntax error: '__declspec(dllimport)'
..\subprojects\factory\factory\cf_hnf.h(44): error C2059: syntax error: '__declspec(dllimport)'
```
and a few errors due to inconsistent annotations by adding/removing `FACTORY_PUBLIC = __declspec(dllexport)` in a few places.