### PR TITLE
Add NOMINMAX for Windows compatibility

### DIFF
--- a/factory/include/factory/templates/ftmpl_array.h
+++ b/factory/include/factory/templates/ftmpl_array.h
@@ -3,6 +3,7 @@
 #ifndef INCL_ARRAY_H
 #define INCL_ARRAY_H
 
+#define NOMINMAX
 #ifndef NOSTREAMIO
 #ifdef HAVE_IOSTREAM
 #include <iostream>


### PR DESCRIPTION
Some Windows compiler still provide their own min/max functions which leads to conflicts such as
```
..\subprojects\factory\factory\include\factory/templates/ftmpl_array.h(32): warning C4003: not enough arguments for function-like macro invocation 'min'
..\subprojects\factory\factory\include\factory/templates/ftmpl_array.h(33): warning C4003: not enough arguments for function-like macro invocation 'max'
..\subprojects\factory\factory\include\factory/templates/ftmpl_array.h(32): error C2059: syntax error: ')'
```
To prevent these name conflicts a simple `#define NOMINMAX` is added.