### PR TITLE
Move ksTest_TS() call inside #ifdef KDEBUG

### DIFF
--- a/kernel/GBEngine/kstd2.cc
+++ b/kernel/GBEngine/kstd2.cc
@@ -2882,8 +2882,8 @@ ideal bba (ideal F, ideal Q,intvec *w,bigintmat *hilb,kStrategy strat)
 
 #ifdef KDEBUG
     strat->P.Init();
-#endif /* KDEBUG */
     kTest_TS(strat);
+#endif /* KDEBUG */
   }
 #ifdef KDEBUG
   if (TEST_OPT_DEBUG) messageSets(strat);


### PR DESCRIPTION
ksTest_* functions are for debugging and should only be called when KDEBUG is defined
