### PR TITLE
Fix bug in nf_icis function from sing.lib

### DIFF
--- a/Singular/LIB/sing.lib
+++ b/Singular/LIB/sing.lib
@@ -339,7 +339,7 @@ EXAMPLE: example nf_icis; shows an example
    }
 //------------ produce generic linear combinations of generators --------------
    int prob;
-   while ( sum(sl) != 0 )
+   while ( sum(sl) > 0 )
    {  prob=prob+1;
       p=p-25; b=b+10;
       i = genericid(i,p,b);          // proc genericid from random.lib


### PR DESCRIPTION
This fixes #1251. 

If some components of an ICIS define a smooth variety the dimension of its singular locus is -1 by convention. Therefore, even if the ICIS is in _normal form_, it is impossible for the sequence of dimensions to add to zero. 

The right condition to check if an ICIS is *not* yet in normal form is `sum(sl) > 0` rather than `sum(sl) != 0`.