### PR TITLE
Fixes return call in modstd

### DIFF
--- a/Singular/LIB/modstd.lib
+++ b/Singular/LIB/modstd.lib
@@ -43,7 +43,7 @@ NOTE:     The procedure computes a standard basis of I (over the rational
 SEE ALSO: modular
 EXAMPLE:  example modStd; shows an example"
 {
-    if (getcores()<=1) { return groebner(I); }
+    if (getcores()<=1) { return(groebner(I)); }
     /* read optional parameter */
     int exactness = 1;
     if (size(#) > 0)


### PR DESCRIPTION
Fixes wrong return call introduced vai commit 0034a76749121a29e11da98e0f2e904e6761ef70.

@hannes14 Do we really need this? This means we cannot run `modstd` one one core. 