### PR TITLE
missing includes with recent FLINT versions

### DIFF
--- a/factory/facMul.cc
+++ b/factory/facMul.cc
@@ -40,6 +40,7 @@
 #include "FLINTconvert.h"
 #include "flint/fq_nmod_vec.h"
 #if __FLINT_RELEASE >= 20503
+#include "flint/mpn_extras.h"
 #include "flint/fmpz_mod.h"
 #endif
 #endif

--- a/libpolys/coeffs/flintcf_Q.cc
+++ b/libpolys/coeffs/flintcf_Q.cc
@@ -10,6 +10,7 @@
 
 #ifdef HAVE_FLINT
 
+#include <gmp.h>
 #include <flint/flint.h>
 #include <flint/fmpz.h>
 #include <flint/fmpq.h>


### PR DESCRIPTION
(needed with recent versions of FLINT, for instance
cb7513b59d050cd2939c631533fb1f1ebae81508)
