### PR TITLE
chg: replacing Groebner errors with Groebner computations

### DIFF
--- a/Singular/LIB/sheafcoh.lib
+++ b/Singular/LIB/sheafcoh.lib
@@ -232,7 +232,7 @@ KEYWORDS: truncated module
 
   if (attrib(M,"isSB")!=1)
   {
-    ERROR("M must be a standard basis!");
+    M = std(M);
   }
 
   dbprint(PL-1, "// M is a SB! ");

--- a/Singular/LIB/triang.lib
+++ b/Singular/LIB/triang.lib
@@ -37,7 +37,7 @@ EXAMPLE: example triangL; shows an example
     // Test, ob G Groebnerbasis eines nulldimensionalen Ideals ist.
     if (attrib(G,"isSB") <> 1)
     {
-        ERROR("The input is no groebner basis.");
+      G = groebner(G);
     }
     else
     {
@@ -210,7 +210,7 @@ NOTE:    Algorithmus von Lazard (siehe: Lazard, D.: Solving
     // Test, ob G Groebnerbasis eines nulldimensionalen Ideals ist.
     if (attrib(G,"isSB") <> 1)
     {
-        ERROR("The input is no groebner basis.");
+      G = groebner(G);
     }
     else
     {
@@ -636,7 +636,7 @@ EXAMPLE: example triangM; shows an example
     // Test, ob G Groebnerbasis ist.
     if (attrib(G,"isSB") <> 1)
     {
-        ERROR("The input is no groebner basis.");
+      G = groebner(G);
     }
 
     // Faktorisierungsschalter setzen.
@@ -817,7 +817,7 @@ EXAMPLE: example triangMH; shows an example
     // Test, ob G Groebnerbasis ist.
     if (attrib(G,"isSB") <> 1)
     {
-        ERROR("The input is no groebner basis.");
+      G = groebner(G);
     }
     if(npars(basering)<>0)
     {
@@ -1192,4 +1192,3 @@ RETURN:  Leitkoeffizient von f bzgl. var(v).
     return(m[size(m),1]);
 }
 ///////////////////////////////////////////////////////////////////////////////
-


### PR DESCRIPTION
This is no solution, but a workaround to https://github.com/oscar-system/Singular.jl/issues/846.

Currently Singular has five library functions which error if not given a Groebner basis, all other library functions that require a Groebner basis simply compute it on demand.  This pull request changes the five functions to also compute Groebner bases on demand instead of returning an error.