### PR TITLE
Run "./configure" before "make dist" when generating factory tarball

### DIFF
--- a/factory/make_factory_dist
+++ b/factory/make_factory_dist
@@ -7,5 +7,5 @@ mv c.ac configure.ac
 sed -e 's:ACLOCAL_AMFLAGS.*:ACLOCAL_AMFLAGS = -I m4:' <Makefile.am >m.am
 mv m.am Makefile.am
 autoreconf  -v -f -i
+./configure
 make dist
-


### PR DESCRIPTION
Otherwise, we fail with an error: "No rule to make target 'dist'"