### PR TITLE
Fix wrong variable name error in ehv.lib

### DIFF
--- a/Singular/LIB/ehv.lib
+++ b/Singular/LIB/ehv.lib
@@ -1040,7 +1040,7 @@ EXAMPLE: example AssEHV; shows an example"
               list l2;
               for (int ii = 1; ii <= n; ii++)
               {
-                l2[i] = "x("+string(ii)+")";
+                l2[ii] = "x("+string(ii)+")";
               }
               l2[size(l2)+1] = "t";
               ring newR = create_ring(ring_list(base)[1], l2, "dp", "no_minpoly");


### PR DESCRIPTION
There was a typo in ehv.lib which led to l2 not being filled and the following create_ring command ending in an error