### PR TITLE
Fix variable ordering in declaration and definition of message()

### DIFF
--- a/kernel/GBEngine/kutil.cc
+++ b/kernel/GBEngine/kutil.cc
@@ -7457,7 +7457,7 @@ poly redtailBba_Ring (LObject* L, int end_pos, kStrategy strat )
 /*2
 *checks the change degree and write progress report
 */
-void message (int i,int* reduc,int* olddeg,kStrategy strat, int red_result)
+void message (int i,int* olddeg,int* reduc,kStrategy strat, int red_result)
 {
   if (i != *olddeg)
   {

--- a/kernel/GBEngine/kutil.h
+++ b/kernel/GBEngine/kutil.h
@@ -524,7 +524,7 @@ void enterpairs (poly h, int k, int ec, int pos,kStrategy strat, int atR = -1);
 void entersets (LObject h);
 void pairs ();
 BOOLEAN sbaCheckGcdPair (LObject* h,kStrategy strat);
-void message (int i,int* reduc,int* olddeg,kStrategy strat,int red_result);
+void message (int i,int* olddeg,int* reduc,kStrategy strat,int red_result);
 void messageStat (int hilbcount,kStrategy strat);
 void messageStatSBA (int hilbcount,kStrategy strat);
 #ifdef KDEBUG


### PR DESCRIPTION
Variable ordering wasn't consistent in message() function (reduc came before olddeg in definition, but olddeg comes before reduc everywhere the function is actually used)
