### PR TITLE
Build system fix to get macos tests passing on github actions

### DIFF
--- a/m4/gmp-check.m4
+++ b/m4/gmp-check.m4
@@ -17,6 +17,7 @@ fi
 ])
 
 BACKUP_CFLAGS=${CFLAGS}
+BACKUP_CXXFLAGS=${CXXFLAGS}
 BACKUP_LIBS=${LIBS}
 
 gmp_found=no
@@ -30,6 +31,7 @@ do
       GMP_LIBS="-lgmp"
     fi
     CFLAGS="${GMP_CPPFLAGS} ${BACKUP_CFLAGS}"
+    CXXFLAGS="${GMP_CPPFLAGS} ${BACKUP_CXXFLAGS}"
     LIBS=" ${GMP_LIBS} ${BACKUP_LIBS}"
     AC_LINK_IFELSE(
       [AC_LANG_PROGRAM([[#include <gmp.h>]],


### PR DESCRIPTION
when building on macos, we need to add an include directory to CXXFLAGS as well as to CFLAGS
