### PR TITLE
allow ssh to be used for debugging github test runners

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -6,6 +6,16 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
+      repo:
+        description: 'Repository to check out (owner/name); defaults to this repo'
+        required: false
+        type: 'string'
+        default: ''
+      ref:
+        description: 'Branch, tag, or SHA to check out; defaults to the dispatch ref'
+        required: false
+        type: 'string'
+        default: ''
       tmate:
         description: 'At the end, create an ssh target on the test runner and wait for ssh'
         required: false
@@ -30,6 +40,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          repository: ${{ github.event.inputs.repo || github.repository }}
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -1,5 +1,8 @@
 name: Run tests
 
+# For how to use the workflow_dispatch inputs below (including the
+# interactive-ssh debugging mode), see doc/Debugging-CI.md.
+
 # Trigger the workflow on push or pull request or manual invocation
 on:
   push:

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: 'number'
         default: 10
+      tmate_limit_access_to_actor:
+        description: "Only accept ssh keys from the dispatching user's github.com profile"
+        required: false
+        type: 'boolean'
+        default: true
 env:
   prefix: "/tmp/prefix"
 
@@ -97,5 +102,7 @@ jobs:
         if: "${{ !cancelled() && github.event.inputs.tmate == 'true' }}"
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: ${{ fromJSON(github.event.inputs.tmate_timeout_minutes) }}
+        with:
+          limit-access-to-actor: ${{ github.event.inputs.tmate_limit_access_to_actor }}
 
 # TODO: code coverage?

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -7,10 +7,15 @@ on:
   workflow_dispatch:
     inputs:
       tmate:
-        description: 'At the end, create an ssh target on test runner and pause ten minutes waiting for ssh'
+        description: 'At the end, create an ssh target on the test runner and wait for ssh'
         required: false
         type: 'boolean'
         default: 'false'
+      tmate_timeout_minutes:
+        description: 'Minutes to wait for an ssh connection before giving up'
+        required: false
+        type: 'number'
+        default: 10
 env:
   prefix: "/tmp/prefix"
 
@@ -78,5 +83,6 @@ jobs:
       - name: Create ssh target on test runner for debugging
         if: "${{ !cancelled() && github.event.inputs.tmate == 'true' }}"
         uses: mxschmitt/action-tmate@v3
+        timeout-minutes: ${{ fromJSON(github.event.inputs.tmate_timeout_minutes) }}
 
 # TODO: code coverage?

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -76,7 +76,7 @@ jobs:
       #- run: cd Tst && ./regress.cmd -s $prefix/bin/Singular Long/ok_l.lst
       #  if: ${{ always() }}
       - name: Create ssh target on test runner for debugging
-        if: ${{ github.event.inputs.tmate == 'true' }}
+        if: "${{ !cancelled() && github.event.inputs.tmate == 'true' }}"
         uses: mxschmitt/action-tmate@v3
 
 # TODO: code coverage?

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -67,5 +67,8 @@ jobs:
 
       #- run: cd Tst && ./regress.cmd -s $prefix/bin/Singular Long/ok_l.lst
       #  if: ${{ always() }}
+      - name: Setup tmate session for debugging
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
 
 # TODO: code coverage?

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -1,8 +1,16 @@
 name: Run tests
 
-# Trigger the workflow on push or pull request
-on: [push, pull_request]
-
+# Trigger the workflow on push or pull request or manual invocation
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      tmate:
+        description: 'At the end, create an ssh target on test runner and pause ten minutes waiting for ssh'
+        required: false
+        type: 'boolean'
+        default: 'false'
 env:
   prefix: "/tmp/prefix"
 
@@ -67,8 +75,8 @@ jobs:
 
       #- run: cd Tst && ./regress.cmd -s $prefix/bin/Singular Long/ok_l.lst
       #  if: ${{ always() }}
-      - name: Setup tmate session for debugging
-        if: ${{ failure() }}
+      - name: Create ssh target on test runner for debugging
+        if: ${{ github.event.inputs.tmate == 'true' }}
         uses: mxschmitt/action-tmate@v3
 
 # TODO: code coverage?

--- a/doc/Debugging-CI.md
+++ b/doc/Debugging-CI.md
@@ -1,0 +1,95 @@
+Debugging GitHub CI runs {#debugging_ci_page}
+========================
+
+The `Run tests` workflow (`.github/workflows/runtests.yml`) runs
+automatically on every push and pull request. It can also be invoked
+manually ("workflow dispatch") from the GitHub web UI or from the
+command line, with a few extra options that are useful for debugging a
+CI failure or experimenting with a build configuration.
+
+Triggering a manual run
+-----------------------
+
+From the web UI: open <https://github.com/Singular/Singular/actions>,
+select `Run tests`, click `Run workflow`, and fill in the form.
+
+From the command line (using [`gh`](https://cli.github.com/)):
+
+    gh workflow run runtests.yml --ref <branch-to-run-from> \
+        [-f key=value ...]
+
+The `--ref` argument selects the branch whose workflow file is used
+for the run. Unless overridden by inputs (below), the same ref is also
+checked out and tested.
+
+Available inputs
+----------------
+
+* `repo` — repository to check out (`owner/name`). Defaults to the
+  repository the run is executing in. Useful for testing upstream
+  branches from a fork without having to push them to the fork first.
+
+* `ref` — branch, tag, or SHA to check out. Defaults to the ref the
+  workflow was dispatched from. Lets a tmate-enabled workflow file on
+  one branch debug a build of any other branch.
+
+* `tmate` — if `true`, open an ssh-accessible shell on the runner
+  (using [`mxschmitt/action-tmate`](https://github.com/mxschmitt/action-tmate))
+  after the test steps finish, whether they passed or failed. Default
+  `false`.
+
+* `tmate_timeout_minutes` — how long to wait for an ssh connection
+  before the session is killed. Default 10. Applies per matrix job, so
+  a dispatch that no one connects to will cost at most
+  `timeout × matrix-size` runner minutes.
+
+* `tmate_limit_access_to_actor` — if `true` (the default), only ssh
+  keys listed at `https://github.com/<dispatching-user>.keys` are
+  accepted. If `false`, the session token printed in the live log is
+  the only credential, and anyone with a GitHub account who can read
+  the log can connect.
+
+Connecting to a tmate session
+-----------------------------
+
+The ssh connection string (`ssh <token>@nyc1.tmate.io` or similar) is
+printed every 5 seconds in the live log of the `Create ssh target on
+test runner for debugging` step. Copy it from there.
+
+When you are done:
+
+* `touch /continue && exit` — lets the remaining workflow steps run
+  and marks the step successful.
+* `touch /fail && exit` — ends the session and marks the step failed.
+* plain `exit` — ends your ssh session, but the action keeps polling
+  until the timeout or a `/continue` sentinel. Prefer one of the
+  above.
+
+The live log of a GitHub Actions run requires an authenticated GitHub
+account (any account, not just a repo collaborator) to view. API
+access to a job's log is blocked until the job completes, so the
+ssh string cannot be scraped programmatically during the session.
+
+Security considerations
+-----------------------
+
+When `tmate_limit_access_to_actor` is `false`, the session token in
+the log is a bearer credential. Anyone who sees the live log while
+the session is open can connect to the runner and read its
+environment, including `GITHUB_TOKEN`. The default (`true`) adds a
+public-key check on top of the token, so a leaked log alone is not
+sufficient to connect — the attacker would also need a matching
+private key.
+
+Note that `tmate` upstream is no longer maintained and the [Homebrew
+formula](https://formulae.brew.sh/formula/tmate) is scheduled to be
+disabled on 2026-12-11. When that happens the macOS jobs will no
+longer be able to install `tmate` and this workflow will need to
+switch to a maintained alternative.
+
+See also
+--------
+
+* [mxschmitt/action-tmate](https://github.com/mxschmitt/action-tmate) —
+  the underlying action, including documentation for inputs not
+  exposed by this workflow (e.g. custom tmate relay host).

--- a/doc/Debugging-CI.md
+++ b/doc/Debugging-CI.md
@@ -49,6 +49,24 @@ Available inputs
   the only credential, and anyone with a GitHub account who can read
   the log can connect.
 
+Why `nyc1.tmate.io`?
+--------------------
+
+GitHub-hosted runners sit behind NAT with no inbound connectivity, so
+you cannot ssh to them directly. `tmate` solves this by having the
+runner make an **outbound** connection to a public relay server
+(`*.tmate.io`, operated by the tmate project) and register a session
+there. Your ssh client then connects to the relay, which proxies the
+bytes back down the runner's pre-established connection. The relay is
+a third-party rendezvous point; the session contents pass through it.
+
+If the tmate project's relay is not an acceptable trust dependency,
+`mxschmitt/action-tmate` supports pointing at a self-hosted
+[`tmate-ssh-server`](https://github.com/tmate-io/tmate-ssh-server)
+instance via its `tmate-server-host`, `tmate-server-port`, and
+fingerprint inputs. This workflow does not expose those inputs
+currently; add them to `runtests.yml` if needed.
+
 Connecting to a tmate session
 -----------------------------
 

--- a/doc/Debugging-CI.md
+++ b/doc/Debugging-CI.md
@@ -74,6 +74,10 @@ The ssh connection string (`ssh <token>@nyc1.tmate.io` or similar) is
 printed every 5 seconds in the live log of the `Create ssh target on
 test runner for debugging` step. Copy it from there.
 
+On first connect, tmate shows a read-only info window with the session
+addresses. Press `q` (or `Ctrl-c`) to dismiss it and drop into the
+shell.
+
 When you are done:
 
 * `touch /continue && exit` — lets the remaining workflow steps run

--- a/doc/How-To-Contribute.md
+++ b/doc/How-To-Contribute.md
@@ -19,6 +19,10 @@ Before sending a pull request to merge your changes, make sure that
     * consider special cases! Optimally all decision branches of new functions should be covered by tests
  * the Singular test suite passes without failure. [Instructions on running the test suite](Running-test) is available on this wiki.
 
+If a GitHub CI run fails in a way that is hard to reproduce locally,
+see [Debugging GitHub CI runs](@ref debugging_ci_page) for how to
+dispatch a manual run with an interactive ssh session on the runner.
+
 @note Almost everything GitHub-related can be done from command-line with the
 following tool <http://hub.github.com>.
 


### PR DESCRIPTION
This PR adds to the existing github test harness to provide an option, when the action is triggered manually, to wait at the end for an ssh connection into the test runner, that can be used for debugging.
