### PR TITLE
fixes primdecs if ideal has size 0

### DIFF
--- a/Singular/LIB/modprimdec.lib
+++ b/Singular/LIB/modprimdec.lib
@@ -1108,10 +1108,12 @@ EXAMPLE: example primdecGTZ_wrapper; shows an example
    }
 
    i=simplify(i,2); // erase 0-generators
-   if ((i[1]==0)||(i[1]==1))
-   {
-     list L = list(ideal(i[1]), ideal(i[1]) );
-     return(list(L));
+   if (ncols(i) >= 1) {
+       if ((i[1]==0)||(i[1]==1))
+       {
+         list L = list(ideal(i[1]), ideal(i[1]) );
+         return(list(L));
+       }
    }
    if((ncols(i)==1)&&(attrib(basering,"ring_cf")==0)) // handle principal ideal
    {

--- a/Singular/LIB/primdec.lib
+++ b/Singular/LIB/primdec.lib
@@ -5719,10 +5719,12 @@ static proc primdecGTZ_i(int patchPrimaryDecomposition,ideal i, list #)
       return(li);
    }
    i=simplify(i,2); // erase 0-generators
-   if ((i[1]==0)||(i[1]==1))
-   {
-     list L = list(ideal(i[1]), ideal(i[1]) );
-     return(list(L));
+   if (ncols(i) >= 1) {
+       if ((i[1]==0)||(i[1]==1))
+       {
+         list L = list(ideal(i[1]), ideal(i[1]) );
+         return(list(L));
+       }
    }
    if((ncols(i)==1)&&(attrib(basering,"ring_cf")==0))
    {
@@ -6112,10 +6114,12 @@ static proc primdecSY_i(int patchPrimaryDecomposition, ideal i, list #)
    }
    i=simplify(i,2);
 
-   if ((i[1]==0)||(i[1]==1))
-   {
-     list L = list(ideal(i[1]), ideal(i[1]) );
-     return(list(L));
+   if (ncols(i) >= 1) {
+       if ((i[1]==0)||(i[1]==1))
+       {
+         list L = list(ideal(i[1]), ideal(i[1]) );
+         return(list(L));
+       }
    }
    if((ncols(i)==1)&&(attrib(basering,"ring_cf")==0))
    {


### PR DESCRIPTION
This should fix undefined behaviour if `ncols(i) < 1`.
For the fix, note [https://www.singular.uni-kl.de/Manual/4-4/sing_422.htm#SEC462](https://www.singular.uni-kl.de/Manual/4-4/sing_422.htm#SEC462) on evaluation of logical expressions.
This should fix the broken Oscar test in oscar-system/Singular.jl#877.