### PR TITLE
Improve error handling for directory retrieval and file truncation

### DIFF
--- a/Singular/emacs.cc
+++ b/Singular/emacs.cc
@@ -312,7 +312,7 @@ int main(int argc, char** argv)
   if (cwd[strlen(cwd)-1] != '/') strcat(cwd, "/");
 
   // Note: option -no-init-file should be equivalent to -q. Anyhow,
-  // xemacs-20.4 sometimes crashed on startup when using -q. Don�t know why.
+  // xemacs-20.4 sometimes crashed on startup when using -q. Do not know why.
   snprintf(syscall,len, "%s %sno-init-file %seval '(progn (setq singular-emacs-home-directory \"%s\") (load-file \"%s\") (singular-other \"%s\" \"%s\" (list ",
           emacs, prefix, prefix, emacs_dir, emacs_load,
           singular, cwd);

--- a/Singular/emacs.cc
+++ b/Singular/emacs.cc
@@ -304,7 +304,7 @@ int main(int argc, char** argv)
     prefix = "-";
   if (getcwd(cwd, MAXPATHLEN) == NULL)
   {
-    error("Error: Cannot determine current working directory.\n");
+    perror("getcwd");
     mainUsage();
     exit(1);
   }

--- a/Singular/emacs.cc
+++ b/Singular/emacs.cc
@@ -302,12 +302,17 @@ int main(int argc, char** argv)
   const char* prefix = "--";
   if (strstr(emacs, "xemacs") || strstr(emacs, "Xemacs") || strstr(emacs, "XEMACS"))
     prefix = "-";
-  getcwd(cwd, MAXPATHLEN);
+  if (getcwd(cwd, MAXPATHLEN) == NULL)
+  {
+    error("Error: Cannot determine current working directory.\n");
+    mainUsage();
+    exit(1);
+  }
   // append / at the end of cwd
   if (cwd[strlen(cwd)-1] != '/') strcat(cwd, "/");
 
   // Note: option -no-init-file should be equivalent to -q. Anyhow,
-  // xemacs-20.4 sometimes crashed on startup when using -q. Don´t know why.
+  // xemacs-20.4 sometimes crashed on startup when using -q. Donï¿½t know why.
   snprintf(syscall,len, "%s %sno-init-file %seval '(progn (setq singular-emacs-home-directory \"%s\") (load-file \"%s\") (singular-other \"%s\" \"%s\" (list ",
           emacs, prefix, prefix, emacs_dir, emacs_load,
           singular, cwd);

--- a/kernel/oswrapper/vspace.cc
+++ b/kernel/oswrapper/vspace.cc
@@ -115,7 +115,10 @@ void *VMem::mmap_segment(int seg) {
 
 void VMem::add_segment() {
   int seg = metapage->segment_count++;
-  ftruncate(fd, METABLOCK_SIZE + metapage->segment_count * SEGMENT_SIZE);
+  if (ftruncate(fd, METABLOCK_SIZE + metapage->segment_count * SEGMENT_SIZE) != 0) {
+    perror("ftruncate");
+    abort();
+  }
   void *map_addr = mmap_segment(seg);
   segments[seg] = VSeg(map_addr);
   Block *top = block_ptr(seg * SEGMENT_SIZE);
@@ -323,8 +326,12 @@ void unlock_metapage() {
 }
 
 void init_metapage(bool create) {
-  if (create)
-    ftruncate(vmem.fd, METABLOCK_SIZE);
+  if (create) {
+    if (ftruncate(vmem.fd, METABLOCK_SIZE) != 0) {
+      perror("ftruncate");
+      abort();
+    }
+  }
   vmem.metapage = (MetaPage *) mmap(
       NULL, METABLOCK_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, vmem.fd, 0);
   if (create) {
@@ -715,7 +722,10 @@ void *VMem::mmap_segment(int seg) {
 
 void VMem::add_segment() {
   int seg = metapage->segment_count++;
-  ftruncate(fd, METABLOCK_SIZE + metapage->segment_count * SEGMENT_SIZE);
+  if (ftruncate(fd, METABLOCK_SIZE + metapage->segment_count * SEGMENT_SIZE) != 0) {
+    perror("ftruncate");
+    abort();
+  }
   void *map_addr = mmap_segment(seg);
   segments[seg] = VSeg(map_addr);
   Block *top = block_ptr(seg * SEGMENT_SIZE);
@@ -931,8 +941,12 @@ void unlock_metapage() {
 }
 
 void init_metapage(bool create) {
-  if (create)
-    ftruncate(vmem.fd, METABLOCK_SIZE);
+  if (create) {
+    if (ftruncate(vmem.fd, METABLOCK_SIZE) != 0) {
+      perror("ftruncate");
+      abort();
+    }
+  }
   vmem.metapage = (MetaPage *) mmap(
       NULL, METABLOCK_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, vmem.fd, 0);
   if (create) {

--- a/kernel/oswrapper/vspace.cc
+++ b/kernel/oswrapper/vspace.cc
@@ -10,6 +10,9 @@
 #endif
 #include <cstddef>
 #include "reporter/si_signals.h"
+#include "resources/feFopen.h"
+#include <errno.h>
+#include <string.h>
 
 #if defined(__GNUC__) && (__GNUC__<9) &&!defined(__clang__)
 
@@ -116,8 +119,11 @@ void *VMem::mmap_segment(int seg) {
 void VMem::add_segment() {
   int seg = metapage->segment_count++;
   if (ftruncate(fd, METABLOCK_SIZE + metapage->segment_count * SEGMENT_SIZE) != 0) {
-    perror("ftruncate");
-    abort();
+    metapage->segment_count--;
+    char err_msg[256];
+    snprintf(err_msg, sizeof(err_msg), "out of memory in vspace:add_segment: %s", strerror(errno));
+    WerrorS(err_msg);
+    return;
   }
   void *map_addr = mmap_segment(seg);
   segments[seg] = VSeg(map_addr);
@@ -328,8 +334,10 @@ void unlock_metapage() {
 void init_metapage(bool create) {
   if (create) {
     if (ftruncate(vmem.fd, METABLOCK_SIZE) != 0) {
-      perror("ftruncate");
-      abort();
+      char err_msg[256];
+      snprintf(err_msg, sizeof(err_msg), "out of memory in vspace:init_metapage: %s", strerror(errno));
+      WerrorS(err_msg);
+      return;
     }
   }
   vmem.metapage = (MetaPage *) mmap(
@@ -723,8 +731,11 @@ void *VMem::mmap_segment(int seg) {
 void VMem::add_segment() {
   int seg = metapage->segment_count++;
   if (ftruncate(fd, METABLOCK_SIZE + metapage->segment_count * SEGMENT_SIZE) != 0) {
-    perror("ftruncate");
-    abort();
+    metapage->segment_count--;
+    char err_msg[256];
+    snprintf(err_msg, sizeof(err_msg), "out of memory in vspace:add_segment: %s", strerror(errno));
+    WerrorS(err_msg);
+    return;
   }
   void *map_addr = mmap_segment(seg);
   segments[seg] = VSeg(map_addr);
@@ -943,8 +954,10 @@ void unlock_metapage() {
 void init_metapage(bool create) {
   if (create) {
     if (ftruncate(vmem.fd, METABLOCK_SIZE) != 0) {
-      perror("ftruncate");
-      abort();
+      char err_msg[256];
+      snprintf(err_msg, sizeof(err_msg), "out of memory in vspace:init_metapage: %s", strerror(errno));
+      WerrorS(err_msg);
+      return;
     }
   }
   vmem.metapage = (MetaPage *) mmap(

--- a/resources/feResource.cc
+++ b/resources/feResource.cc
@@ -163,16 +163,18 @@ void feInitResources(const char* argv0)
   {
     //WarnS("illegal argv[0]==NULL");
     feArgv0 = (char*)malloc(MAXPATHLEN+strlen("/Singular"));
-    if (feArgv0 != NULL)
+    if (feArgv0 == NULL)
     {
-      if (getcwd(feArgv0, MAXPATHLEN) == NULL)
-      {
-        strcpy(feArgv0, "Singular");
-      }
-      else
-      {
-        strcat(feArgv0,"/Singular");
-      }
+      fprintf(stderr, "out of memory in initialization\n");
+      abort();
+    }
+    if (getcwd(feArgv0, MAXPATHLEN) == NULL)
+    {
+      strcpy(feArgv0, "Singular");
+    }
+    else
+    {
+      strcat(feArgv0,"/Singular");
     }
   }
   else

--- a/resources/feResource.cc
+++ b/resources/feResource.cc
@@ -163,8 +163,17 @@ void feInitResources(const char* argv0)
   {
     //WarnS("illegal argv[0]==NULL");
     feArgv0 = (char*)malloc(MAXPATHLEN+strlen("/Singular"));
-    getcwd(feArgv0, MAXPATHLEN);
-    strcat(feArgv0,"/Singular");
+    if (feArgv0 != NULL)
+    {
+      if (getcwd(feArgv0, MAXPATHLEN) == NULL)
+      {
+        strcpy(feArgv0, "Singular");
+      }
+      else
+      {
+        strcat(feArgv0,"/Singular");
+      }
+    }
   }
   else
     feArgv0 = strdup(argv0);

--- a/resources/omFindExec.c
+++ b/resources/omFindExec.c
@@ -94,15 +94,15 @@ static char * omFindExec_link (const char *name, char* executable)
         *next = '\0';
 
         if ((tbuf[0] == '.' && tbuf[1] == '\0') || tbuf[0] == '\0') {
-      #ifdef HAVE_GETCWD
-          if (getcwd (tbuf, MAXPATHLEN) == NULL)
-            goto next_path_entry;
-      #else
-      # ifdef HAVE_GETWD
-          if (getwd (tbuf) == NULL)
-            goto next_path_entry;
-      # endif
-      #endif
+#ifdef HAVE_GETCWD
+   if (getcwd (tbuf, MAXPATHLEN) == NULL)
+      goto next_path_entry;
+#else
+# ifdef HAVE_GETWD
+   if (getwd (tbuf) == NULL)
+      goto next_path_entry;
+# endif
+#endif
         }
 
         if (tbuf[strlen(tbuf)-1] != '/') strcat(tbuf, "/");

--- a/resources/omFindExec.c
+++ b/resources/omFindExec.c
@@ -94,13 +94,15 @@ static char * omFindExec_link (const char *name, char* executable)
         *next = '\0';
 
         if ((tbuf[0] == '.' && tbuf[1] == '\0') || tbuf[0] == '\0') {
-#ifdef HAVE_GETCWD
-          getcwd (tbuf, MAXPATHLEN);
-#else
-# ifdef HAVE_GETWD
-          getwd (tbuf);
-# endif
-#endif
+      #ifdef HAVE_GETCWD
+          if (getcwd (tbuf, MAXPATHLEN) == NULL)
+            goto next_path_entry;
+      #else
+      # ifdef HAVE_GETWD
+          if (getwd (tbuf) == NULL)
+            goto next_path_entry;
+      # endif
+      #endif
         }
 
         if (tbuf[strlen(tbuf)-1] != '/') strcat(tbuf, "/");
@@ -113,6 +115,7 @@ static char * omFindExec_link (const char *name, char* executable)
           return executable;
         }
 
+next_path_entry:
         if (*p != '\0')
         {
           p ++;


### PR DESCRIPTION
Add the error handler for getcwd and ftruncate. Now gcc warns that we should check the results for the two functions