### PR TITLE
correct a spelling typo

### DIFF
--- a/Singular/htable.cc
+++ b/Singular/htable.cc
@@ -121,5 +121,5 @@ void htable_Print(stablerec *d)
       while(p!=NULL) { cnt2++;p=p->next;}
     }
   }
-  Print("%d colums, %d entries, size:%d",cnt,cnt2,lt->max);
+  Print("%d columns, %d entries, size:%d",cnt,cnt2,lt->max);
 }

--- a/Tst/Manual/kernelLattice.tst
+++ b/Tst/Manual/kernelLattice.tst
@@ -13,7 +13,7 @@ intmat C[2][4] =
 1,0,2,0,
 0,1,2,0;
 // should result in a matrix whose
-// colums create the same  lattice as
+// columns create the same  lattice as
 // [-2,-2,1,0], [0,0,0,1]
 intmat D = kernelLattice(C);
 print(D);

--- a/Tst/Manual/latticeBasis.tst
+++ b/Tst/Manual/latticeBasis.tst
@@ -11,7 +11,7 @@ intmat C[2][4] =
 1,1,2,0,
 2,3,4,0;
 // should result in a matrix whose
-// colums create the same  lattice as
+// columns create the same  lattice as
 // [0,1],[1,0]
 intmat D = latticeBasis(C);
 print(D);


### PR DESCRIPTION
Correct a spelling typo in source as emitted by Lintian, spelling-error-in-binary tag.