### PR TITLE
cstring include for strlen

### DIFF
--- a/factory/cf_factor.cc
+++ b/factory/cf_factor.cc
@@ -36,6 +36,8 @@
 #include "fac_multivar.h"
 
 #include "int_int.h"
+#include <cstring>
+
 #ifdef HAVE_NTL
 #include "NTLconvert.h"
 #endif


### PR DESCRIPTION
building with clang 21 (on Linux) and without omalloc errors out without this change.