### PR TITLE
Checking FLINT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,7 +97,7 @@ AC_SUBST(SPASM_LIB)
 
 SING_CHECK_GMP
 LB_CHECK_NTL(5.0,,AC_MSG_WARN([Unable to find NTL (which is strongly recommended) on your machine: please use --with-ntl=PATH_TO_DIR_CONTAINING_LIB_AND_INCLUDE (see also ./configure --help if you do not understand what we are talking about)]))
-LB_CHECK_FLINT(2.3,,AC_MSG_WARN([Unable to find FLINT (which is strongly recommended) on your machine: please use --with-flint=PATH_TO_DIR_CONTAINING_LIB_AND_INCLUDE (see also ./configure --help if you do not understand what we are talking about)]))
+LB_CHECK_FLINT(3.0,,AC_MSG_WARN([Unable to find FLINT (which is strongly recommended) on your machine: please use --with-flint=PATH_TO_DIR_CONTAINING_LIB_AND_INCLUDE (see also ./configure --help if you do not understand what we are talking about)]))
 
 AC_CHECK_HEADERS(mpfr.h)
 

--- a/factory/configure.ac
+++ b/factory/configure.ac
@@ -221,7 +221,7 @@ AC_SEARCH_LIBS(sem_wait,[rt pthreads pthread],[],[
 
 LB_CHECK_NTL(5.0,,AC_MSG_WARN([Unable to find NTL (which is strongly recommended) on your machine: please use --with-ntl=PATH_TO_DIR_CONTAINING_LIB_AND_INCLUDE (see also ./configure --help if you do not understand what we are talking about)]))
 
-LB_CHECK_FLINT(2.4,,AC_MSG_WARN([Unable to find FLINT (which is strongly recommended) on your machine: please use --with-flint=PATH_TO_DIR_CONTAINING_LIB_AND_INCLUDE (see also ./configure --help if you do not understand what we are talking about)]))
+LB_CHECK_FLINT(3.0,,AC_MSG_WARN([Unable to find FLINT (which is strongly recommended) on your machine: please use --with-flint=PATH_TO_DIR_CONTAINING_LIB_AND_INCLUDE (see also ./configure --help if you do not understand what we are talking about)]))
 
 # arithmetic shift
 #AC_MSG_CHECKING(whether your compiler does arithmetic shifts)

--- a/libpolys/configure.ac
+++ b/libpolys/configure.ac
@@ -51,7 +51,7 @@ SING_CHECK_GMP
 
 LB_CHECK_NTL(5.0,,AC_MSG_WARN([Unable to find NTL (which is strongly recommended) on your machine: please use --with-ntl=PATH_TO_DIR_CONTAINING_LIB_AND_INCLUDE (see also ./configure --help if you do not understand what we are talking about)]))
 
-LB_CHECK_FLINT(2.4,,AC_MSG_WARN([Unable to find FLINT (which is strongly recommended) on your machine: please use --with-flint=PATH_TO_DIR_CONTAINING_LIB_AND_INCLUDE (see also ./configure --help if you do not understand what we are talking about)]))
+LB_CHECK_FLINT(3.0,,AC_MSG_WARN([Unable to find FLINT (which is strongly recommended) on your machine: please use --with-flint=PATH_TO_DIR_CONTAINING_LIB_AND_INCLUDE (see also ./configure --help if you do not understand what we are talking about)]))
 
 SING_CHECK_JULIA
 

--- a/m4/flint-check.m4
+++ b/m4/flint-check.m4
@@ -25,8 +25,10 @@ AC_ARG_WITH(flint,
              ],
              [if test "x$withval" = xyes ; then
                         FLINT_HOME_PATH="DEFAULTS ${DEFAULT_CHECKING_PATH}"
+                        flint_requested="yes"
               elif test "x$withval" != xno ; then
                         FLINT_HOME_PATH="$withval"
+                        flint_requested="yes"
              fi],
              [FLINT_HOME_PATH="DEFAULTS ${DEFAULT_CHECKING_PATH}"])
 
@@ -76,6 +78,9 @@ else
         FLINT_CFLAGS=""
         FLINT_LIBS=""
         FLINT_HOME=""
+        if test "x$flint_requested" = "xyes" ; then
+            AC_MSG_ERROR([Configure error: FLINT requested, but not found])
+        fi
 fi
 AC_SUBST(FLINT_CFLAGS)
 AC_SUBST(FLINT_LIBS)

--- a/m4/flint-check.m4
+++ b/m4/flint-check.m4
@@ -79,7 +79,7 @@ else
         FLINT_LIBS=""
         FLINT_HOME=""
         if test "x$flint_requested" = "xyes" ; then
-            AC_MSG_ERROR([Configure error: FLINT requested, but not found])
+            AC_MSG_FAILURE([Configure error: FLINT requested, but not found])
         fi
 fi
 AC_SUBST(FLINT_CFLAGS)


### PR DESCRIPTION
With these changes `configure` fails if FLINT is requested but not found, see #1320.
This also enforces FLINT version `>=3.0`.