### PR TITLE
Cleanup gap parentheses

### DIFF
--- a/libpolys/coeffs/rintegers2.cc
+++ b/libpolys/coeffs/rintegers2.cc
@@ -414,7 +414,7 @@ static nMapFunc nrzSetMap(const coeffs src, const coeffs /*dst*/)
   {
     return ndCopyMap; //nrzCopyMap;
   }
-  if ((src->rep==n_rep_gap_gmp) /*&& nCoeff_is_Z(src)*/)
+  if (src->rep==n_rep_gap_gmp /*&& nCoeff_is_Z(src)*/)
   {
     return ndCopyMap; //nrzCopyMap;
   }

--- a/libpolys/coeffs/rintegers2.cc
+++ b/libpolys/coeffs/rintegers2.cc
@@ -414,7 +414,8 @@ static nMapFunc nrzSetMap(const coeffs src, const coeffs /*dst*/)
   {
     return ndCopyMap; //nrzCopyMap;
   }
-  if (src->rep==n_rep_gap_gmp /*&& nCoeff_is_Z(src)*/)
+  // Historically: && nCoeff_is_Z(src)
+  if (src->rep==n_rep_gap_gmp)
   {
     return ndCopyMap; //nrzCopyMap;
   }

--- a/libpolys/coeffs/rmodulo2m.cc
+++ b/libpolys/coeffs/rmodulo2m.cc
@@ -700,7 +700,7 @@ static nMapFunc nr2mSetMap(const coeffs src, const coeffs dst)
   {
     return nr2mMapGMP;
   }
-  if ((src->rep==n_rep_gap_gmp) /*&& nCoeff_is_Z(src)*/)
+  if (src->rep==n_rep_gap_gmp /*&& nCoeff_is_Z(src)*/)
   {
     return nr2mMapZ;
   }

--- a/libpolys/coeffs/rmodulo2m.cc
+++ b/libpolys/coeffs/rmodulo2m.cc
@@ -700,7 +700,8 @@ static nMapFunc nr2mSetMap(const coeffs src, const coeffs dst)
   {
     return nr2mMapGMP;
   }
-  if (src->rep==n_rep_gap_gmp /*&& nCoeff_is_Z(src)*/)
+  // Historically: && nCoeff_is_Z(src)
+  if (src->rep==n_rep_gap_gmp)
   {
     return nr2mMapZ;
   }

--- a/libpolys/coeffs/rmodulon.cc
+++ b/libpolys/coeffs/rmodulon.cc
@@ -809,7 +809,7 @@ nMapFunc nrnSetMap(const coeffs src, const coeffs dst)
   {
     return nrnMapZ;
   }
-  if ((src->rep==n_rep_gap_gmp) /*&& nCoeff_is_Z(src)*/)
+  if (src->rep==n_rep_gap_gmp /*&& nCoeff_is_Z(src)*/)
   {
     return nrnMapZ;
   }

--- a/libpolys/coeffs/rmodulon.cc
+++ b/libpolys/coeffs/rmodulon.cc
@@ -809,7 +809,8 @@ nMapFunc nrnSetMap(const coeffs src, const coeffs dst)
   {
     return nrnMapZ;
   }
-  if (src->rep==n_rep_gap_gmp /*&& nCoeff_is_Z(src)*/)
+  // Historically: && nCoeff_is_Z(src)
+  if (src->rep==n_rep_gap_gmp)
   {
     return nrnMapZ;
   }


### PR DESCRIPTION
Cleanup the unnecessary  parentheses. fix the warnings from clang