### PR TITLE
Fix NTL and FLINT PRNG seeding in factoryseed()

### DIFF
--- a/factory/cf_random.cc
+++ b/factory/cf_random.cc
@@ -14,6 +14,10 @@
 #include "gfops.h"
 #include "imm.h"
 
+#ifdef HAVE_NTL
+#include <NTL/ZZ.h>
+#endif
+
 #ifdef HAVE_FLINT
 #ifndef __GMP_BITS_PER_MP_LIMB
 #define __GMP_BITS_PER_MP_LIMB GMP_LIMB_BITS
@@ -190,8 +194,13 @@ void factoryseed ( int s )
 #ifdef HAVE_FLINT
 #if (__FLINT_RELEASE>=30300)
     flint_rand_init(FLINTrandom);
+    flint_rand_set_seed(FLINTrandom, (ulong)s, (ulong)s);
 #else
     flint_randinit(FLINTrandom);
+    flint_randseed(FLINTrandom, (ulong)s, (ulong)s);
 #endif
+#endif
+#ifdef HAVE_NTL
+    NTL::SetSeed(NTL::ZZ(NTL::INIT_VAL, (long)s));
 #endif
 }


### PR DESCRIPTION
## Summary

- Seed FLINT's PRNG with the user-provided seed after `flint_rand_init()`
- Seed NTL's PRNG via `NTL::SetSeed()` with the user-provided seed

## Details

`factoryseed()` in `factory/cf_random.cc` seeds factory's own PRNG from `--random=SEED` but had two bugs:

1. **FLINT**: `flint_rand_init()` reinitializes the PRNG to fixed constants, but `flint_randseed()` was never called afterward to set the user's seed. This made FLINT-based random operations (e.g., irreducible polynomial generation) ignore `--random=SEED`.

2. **NTL**: The PRNG was never seeded at all, leaving it initialized from `time(0)/clock()/PID`. This made NTL-dependent operations non-deterministic across runs even with `--random=SEED`. Affected operations include univariate factorization over Z/pZ for degree >= 300, factorization over Z/pZ(alpha), and factorization over GF(2).

Both bugs cause non-reproducible results when using `--random=SEED` for benchmarking or regression testing. With this fix, all three PRNGs (factory, FLINT, NTL) are seeded from the user-provided seed.

## Testing

Verified on the full Singular test suite (673 tests: Short/ok_s, Buch/buch, Old/universal, Plural/short, Long/ok_l). No test failures or result differences from this change — it only affects seeding, not the algorithms themselves.

Confirmed that benchmark timing variance decreases with this fix when using `--random=42` (instruction counts become deterministic for single-process computations).

---
*This PR was researched and written by an AI assistant (Claude) on behalf of Brent Baccala (cosine@freesoft.org), based on analysis of benchmark non-determinism traced to unseeded PRNGs in the factory library.*