### PR TITLE
Fix buffer overflow in jjKLAMMER_PL snprintf size calculation

### DIFF
--- a/Singular/iparith.cc
+++ b/Singular/iparith.cc
@@ -8117,7 +8117,7 @@ static BOOLEAN jjKLAMMER_PL(leftv res, leftv u)
         omFree((ADDRESS)nn);
         return TRUE;
       }
-      snprintf(s,len-(nn-s),",%d",(int)(long)v->Data());
+      snprintf(s,len-(s-nn),",%d",(int)(long)v->Data());
     } while (v->next!=NULL);
     while (*s!='\0') s++;
     nn=strcat(nn,")");


### PR DESCRIPTION
## Summary

- Fix swapped operands in `snprintf` buffer size calculation in `jjKLAMMER_PL` (`Singular/iparith.cc`)
- The remaining buffer size was computed as `len-(nn-s)`, but since `s >= nn` (s advances forward), `nn-s` is negative, making the computed size *larger* than the buffer
- Fixed to `len-(s-nn)` to correctly compute remaining space

## Details

When building variable names from multi-index expressions (e.g., `a_(3,2,3)`), `jjKLAMMER_PL` iterates through indices and appends `,%d` to a buffer using `snprintf`. The incorrect sign in the size calculation told `snprintf` the buffer was larger than allocated.

With omalloc this was masked because omalloc over-allocates to size-class boundaries. With system malloc (`--disable-omalloc`), glibc's `_FORTIFY_SOURCE` detects the overflow and aborts, causing a segfault on `Short/bug_bucket.tst`.

## Test plan

- [x] `./regress.cmd -s .../Singular Short/bug_bucket.tst` passes with `--disable-omalloc` build (was segfaulting before)

---
*This PR was researched and written by an AI assistant (Claude) on behalf of Brent Baccala (cosine@freesoft.org), based on debugging a segfault in the system-malloc build.*