### PR TITLE
More CI infrastructure

### DIFF
--- a/.github/workflows/ci-oscar-full.yml
+++ b/.github/workflows/ci-oscar-full.yml
@@ -3,6 +3,10 @@ name: CI with Oscar (full test suite)
 on:
   workflow_dispatch:
     inputs:
+      pr_number:
+        description: 'PR number to test instead of the selected branch (optional)'
+        required: false
+        type: string
       subset:
         description: Oscar test subset to run
         type: choice
@@ -13,13 +17,17 @@ on:
         default: short
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.inputs.pr_number != '' && format('pr-{0}', github.event.inputs.pr_number) || github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 env:
   JULIA_NUM_THREADS: '2'
   OPENBLAS_NUM_THREADS: '1'
   OMP_NUM_THREADS: '1'
+  SINGULAR_CHECKOUT_REF: ${{ github.event.inputs.pr_number != '' && format('refs/pull/{0}/merge', github.event.inputs.pr_number) || github.ref }}
 
 jobs:
   build-singular-override:
@@ -31,6 +39,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           path: SINGULARROOT
+          ref: ${{ env.SINGULAR_CHECKOUT_REF }}
+
+      - name: Show tested ref
+        run: |
+          echo "Testing ref: $SINGULAR_CHECKOUT_REF"
+          if [ -n '${{ github.event.inputs.pr_number }}' ]; then
+            echo "Testing PR #${{ github.event.inputs.pr_number }} via merge ref"
+          fi
 
       - name: Set up Julia
         uses: julia-actions/setup-julia@v2
@@ -93,6 +109,8 @@ jobs:
       OSCAR_TEST_SUBSET: ${{ matrix.oscar-subset }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ env.SINGULAR_CHECKOUT_REF }}
 
       - name: Download override prefix
         uses: actions/download-artifact@v4

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -68,4 +68,77 @@ jobs:
       #- run: cd Tst && ./regress.cmd -s $prefix/bin/Singular Long/ok_l.lst
       #  if: ${{ always() }}
 
+  extra:
+
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 120
+
+    steps:
+
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+
+        run: |
+
+          sudo apt-get update
+          sudo apt-get install -y \
+            sharutils libgmp-dev libreadline-dev libmpfr-dev libntl-dev libcdd-dev \
+            4ti2 normaliz libopenblas-dev libflint-dev \
+            cmake
+
+      - run: ./autogen.sh
+
+      - run: ./configure --prefix=$prefix --enable-gfanlib --with-ntl --with-flint
+
+      - run: make -j"$(nproc)"
+
+      - run: make install
+
+      - name: Build extra CI list
+
+        run: |
+
+          cat > Tst/Extra.ci.lst <<'EOF'
+          Buch/Example_1_8_7.tst
+          Short/bug_53.tst
+          Short/bug_55.tst
+          Short/bug_div.tst
+          Short/rInit.tst
+          Short/solve_s.tst
+          Long/tropical.tst
+          Manual/fglm_solve.tst
+          Manual/laguerre_solve.tst
+          Manual/lex_solve.tst
+          Manual/number_pi.tst
+          Manual/simplex.tst
+          Manual/simplexOut.tst
+          Manual/solve.tst
+          Manual/triangL_solve.tst
+          Manual/triangLf_solve.tst
+          Manual/triangM_solve.tst
+          Manual/triang_solve.tst
+          EOF
+
+      - name: Run extra regression tests
+
+        run: cd Tst && ./regress.cmd -s $prefix/bin/Singular Extra.ci.lst
+
+      - name: Upload regression artifacts
+
+        if: ${{ failure() }}
+
+        uses: actions/upload-artifact@v4
+
+        with:
+
+          name: singular-extra-regressions
+          path: |
+            Tst/**/*.diff
+            Tst/**/*.stat.diff
+            Tst/**/*.new.res
+            Tst/**/*.new.stat
+            Tst/Extra.ci.lst
+
 # TODO: code coverage?


### PR DESCRIPTION
Add the possibility to manually run the full/short/long Oscar test suit on a PR (useful if it involves critical changes). Add a manual full Singular test suit (expected to fail for the moment). Add some more regular tests (expected to fail currently, and not required to merge), and expected to pass once #1348 is in.