### PR TITLE
Adds prune including tracing of reduced components

### DIFF
--- a/kernel/ideals.cc
+++ b/kernel/ideals.cc
@@ -2865,6 +2865,28 @@ ideal idMinEmbedding(ideal arg,BOOLEAN inPlace, intvec **w)
   return res;
 }
 
+ideal idMinEmbedding_v(ideal arg,BOOLEAN inPlace, intvec **w, int* g)
+{
+  if (idIs0(arg))
+  {
+    if (g!=NULL)
+    {
+      for(int i=0;i<arg->rank;i++) g[i]=i+1;
+    }
+    return arg;
+  }
+  int *red_comp=(int*)omAlloc((arg->rank+1)*sizeof(int));
+  int del=0;
+  ideal res=idMinEmbedding1(arg,FALSE,w,red_comp,del);
+  for(int i=1;i<=arg->rank;i++)
+  {
+    g[i-1]=red_comp[i];
+  }
+  idDeleteComps(res,red_comp,del);
+  omFree(red_comp);
+  return res;
+}
+
 ideal idMinEmbedding_with_map(ideal arg,intvec **w, ideal &trans)
 {
   int *red_comp=(int*)omAlloc((arg->rank+1)*sizeof(int));

--- a/kernel/ideals.h
+++ b/kernel/ideals.h
@@ -161,6 +161,7 @@ poly idMinor(matrix a, int ar, unsigned long which, ideal R = NULL);
 ideal   idMinors(matrix a, int ar, ideal R = NULL);
 
 ideal idMinEmbedding(ideal arg,BOOLEAN inPlace=FALSE, intvec **w=NULL);
+ideal idMinEmbedding_v(ideal arg,BOOLEAN inPlace=FALSE, intvec **w=NULL, int*red_comp=NULL);
 ideal idMinEmbedding_with_map(ideal arg,intvec **w, ideal &trans);
 ideal idMinEmbedding_with_map_v(ideal arg,intvec **w, ideal &trans, int*red_comp);
 


### PR DESCRIPTION
This PR adds the minimal embedding command including the tracing of reduced components but without keeping the map.