### PR TITLE
Fixes integer overflows in primdecint.lib

### DIFF
--- a/Singular/LIB/primdecint.lib
+++ b/Singular/LIB/primdecint.lib
@@ -486,7 +486,7 @@ EXAMPLE: example minAssZ; shows an example
    //=== find h in Z such that I is the intersection of I:h and I,h
    //=== and I:h =IQ[variables] intersected with Z[variables]
    list H=coefZ(J);
-   int h=H[2];
+   bigint h=H[2];
    J=J,h;
    //=== call associated primes over Z for I,h
    list M;
@@ -1003,21 +1003,20 @@ static proc coefPrimeZ(ideal I)
 {
 //=== computes the primes occurring in the product of the leading coefficients
 //=== of I
-   number h=1;
-   int i;
+   int i,j;
    I = simplify(I,2); // del zero generators
-   for(i=1;i<=size(I);i++)
-   {
-      h=h*leadcoef(I[i]);  // besser machen (gleich zerlegen,
-                           // nicht ausmultiplizieren)
+   list tmp;
+   ideal factors = 0;
+   for (i=1; i<=size(I); i++) {
+      tmp = primefactors(bigint(leadcoef(I[i])))[1];
+      for (j=1; j<=size(tmp); j++) {
+         factors = factors + tmp[j];
+      }
    }
-   def R=basering;
-   ring Rhelp=0,x,dp;
-   number h=imap(R,h);
-   //list L=PollardRho(h,5000,1);
-   list L=primefactors(h)[1];
-   for(i=1;i<=size(L);i++){L[i]=int(L[i]);}
-   setring R;
+   list L;
+   for (i=1; i<=size(factors); i++) {
+      L= insert(L,bigint(factors[i]));
+   }
    return(L);
 }
 
@@ -1030,7 +1029,7 @@ static proc coefZ(ideal I)
 //===   <g_1,...,g_s>Z[variables]:h^infinity = IQ[variables] intersected
 //===                                          with Z[variables]
 //=== returns a list with IQ[variables] intersected with Z[variables] and h
-   int h=1;
+   bigint h=1;
    int i,e;
    ideal K=1;
    attrib(I,"isSB",1);

--- a/Singular/LIB/primdecint.lib
+++ b/Singular/LIB/primdecint.lib
@@ -333,7 +333,7 @@ EXAMPLE: example primdecZ; shows an example
    //=== and I:h = IQ[variables] intersected with Z[variables]
    list H =coefZ(J);
    ideal Y=H[1];
-   int h=H[2];
+   bigint h=H[2];
    J=J,h;
    //=== call primary decomposition over Z for <I,h>
    ideal testid = 1;

--- a/Singular/LIB/primdecint.lib
+++ b/Singular/LIB/primdecint.lib
@@ -605,7 +605,7 @@ EXAMPLE: example heightZ; shows an example
    //=== find h in Z such that I is the intersection of I:h and I,h
    //=== and I:h =IQ[variables] intersected with Z[variables]
    list H=coefZ(J);
-   int h=H[2];
+   bigint h=H[2];
    J=J,h;
    //=== call height over Z for I,h
    if(h!=1)
@@ -888,7 +888,7 @@ EXAMPLE: example equidimZ; shows an example
    E=coefZ(E)[1];
    //=== find h in Z such that I is the intersection of I:h and I,h
    //=== and I:h =IQ[variables] intersected with Z[variables]
-   int h =coefZ(J)[2];
+   bigint h =coefZ(J)[2];
    J=J,h;
    //=== call equidimensional part over Z for I,h
    ideal M;

--- a/Singular/LIB/primdecint.lib
+++ b/Singular/LIB/primdecint.lib
@@ -707,7 +707,7 @@ EXAMPLE: example radicalZ; shows an example
    //=== find h in Z such that I is the intersection of I:h and I,h
    //=== and I:h =IQ[variables] intersected with Z[variables]
    list H=coefZ(J);
-   int h=H[2];
+   bigint h=H[2];
    J=J,h;
    //=== call radical over Z for I,h
    if(h!=1)

--- a/Tst/Short/ok_s.lst
+++ b/Tst/Short/ok_s.lst
@@ -166,6 +166,8 @@ ncfactor_usl2_reducible_bug_s
 ncfactor_usl2_s
 polyclass
 primdec3
+../Manual/equidimZ
+../Manual/heightZ
 reesclos
 resources_s
 nchilb_rcolon1


### PR DESCRIPTION
This PR fixes integer overflows in `primdecint.lib`. It also improves `coefPrimeZ`'s computation of prime factors.
In particular, this fixes  https://github.com/oscar-system/Oscar.jl/issues/6059.